### PR TITLE
feat: push data to TN based on UNIX timestamp

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -105,12 +105,14 @@ export abstract class BaseTNClient<T extends EnvironmentType> {
    * @param streamId - The ID of the stream to deploy.
    * @param streamType - The type of the stream.
    * @param synchronous - Whether the deployment should be synchronous.
+   * @param contractVersion
    * @returns A promise that resolves to a generic response containing the transaction receipt.
    */
   async deployStream(
     streamId: StreamId,
     streamType: StreamType,
     synchronous?: boolean,
+    contractVersion?: number
   ): Promise<GenericResponse<TxReceipt>> {
     return await deployStream({
       streamId,
@@ -118,6 +120,7 @@ export abstract class BaseTNClient<T extends EnvironmentType> {
       synchronous,
       kwilClient: this.getKwilClient(),
       kwilSigner: this.getKwilSigner(),
+      contractVersion: contractVersion
     });
   }
 

--- a/src/contracts-api/composedStream.ts
+++ b/src/contracts-api/composedStream.ts
@@ -13,7 +13,7 @@ export const ErrorStreamNotComposed = "stream is not a composed stream";
 
 export interface TaxonomySet {
   taxonomyItems: TaxonomyItem[];
-  startDate?: DateString;
+  startDate: DateString | number;
 }
 
 export interface TaxonomyItem {
@@ -82,7 +82,7 @@ export class ComposedStream extends Stream {
       weight: string;
       created_at: number;
       version: number;
-      start_date: string;
+      start_date: string | number;
     }[];
 
     const result = await this.call<TaxonomyResult>("describe_taxonomies", [
@@ -93,7 +93,7 @@ export class ComposedStream extends Stream {
       .mapRight((records) => {
         const taxonomyItems: Map<DateString, TaxonomyItem[]> = records.reduce(
           (acc, record) => {
-            const currentArray = acc.get(record.start_date) || [];
+            const currentArray = acc.get(<string>record.start_date) || [];
             currentArray.push({
               childStream: {
                 streamId: StreamId.fromString(record.child_stream_id).throw(),
@@ -103,13 +103,13 @@ export class ComposedStream extends Stream {
               },
               weight: record.weight,
             });
-            acc.set(record.start_date, currentArray);
+            acc.set(<string>record.start_date, currentArray);
             return acc;
           },
           new Map<DateString, TaxonomyItem[]>(),
         );
 
-        let startDate: DateString | undefined;
+        let startDate: string | number;
         if (records.length > 0 && records[0].start_date) {
           startDate = records[0].start_date;
         }

--- a/src/contracts-api/deployStream.ts
+++ b/src/contracts-api/deployStream.ts
@@ -5,6 +5,8 @@ import { CompiledKuneiform } from "@kwilteam/kwil-js/dist/core/payload";
 import {
   composedStreamTemplate,
   primitiveStreamTemplate,
+  composedStreamTemplateUnix,
+  primitiveStreamTemplateUnix
 } from "../contracts/contractsContent";
 import { GenericResponse } from "@kwilteam/kwil-js/dist/core/resreq";
 import { KwilSigner } from "@kwilteam/kwil-js";
@@ -16,6 +18,7 @@ export interface DeployStreamInput {
   kwilClient: Kwil<any>;
   kwilSigner: KwilSigner;
   synchronous?: boolean;
+  contractVersion?: number;
 }
 
 export interface DeployStreamOutput {
@@ -31,7 +34,7 @@ export async function deployStream(
   input: DeployStreamInput,
 ): Promise<GenericResponse<TxReceipt>> {
   try {
-    const schema = await getContract(input.streamType);
+    const schema = await getContract(input.streamType, input.contractVersion);
 
     schema.name = input.streamId.getId();
 
@@ -53,14 +56,15 @@ export async function deployStream(
 /**
  * Returns the contract content based on the stream type.
  * @param streamType - The type of the stream.
+ * @param contractVersion
  * @returns The contract content as a Uint8Array.
  */
-async function getContract(streamType: StreamType): Promise<CompiledKuneiform> {
+async function getContract(streamType: StreamType, contractVersion?: number): Promise<CompiledKuneiform> {
   switch (streamType) {
     case StreamType.Composed:
-      return composedStreamTemplate;
+      return contractVersion === 2 ? composedStreamTemplateUnix : composedStreamTemplate;
     case StreamType.Primitive:
-      return primitiveStreamTemplate;
+      return contractVersion === 2 ? primitiveStreamTemplateUnix : primitiveStreamTemplate;
     default:
       throw new Error(`Unknown stream type: ${streamType}`);
   }

--- a/src/contracts-api/primitiveStream.ts
+++ b/src/contracts-api/primitiveStream.ts
@@ -84,7 +84,7 @@ export class PrimitiveStream extends Stream {
   }
 }
 export interface InsertRecordInput {
-  dateValue: string;
+  dateValue: string | number;
   // value is a string to support arbitrary precision
   value: string;
 }

--- a/src/contracts-api/stream.ts
+++ b/src/contracts-api/stream.ts
@@ -20,19 +20,19 @@ import {
 } from "./contractValues";
 
 export interface GetRecordInput {
-  dateFrom?: DateString;
-  dateTo?: DateString;
+  dateFrom?: DateString | number;
+  dateTo?: DateString | number;
   frozenAt?: number;
-  baseDate?: DateString;
+  baseDate?: DateString | number;
 }
 
 export interface GetFirstRecordInput {
-  afterDate?: DateString;
-  frozenAt?: DateString;
+  afterDate?: DateString | number;
+  frozenAt?: DateString | number;
 }
 
 export interface StreamRecord {
-  dateValue: DateString;
+  dateValue: DateString | number;
   value: string;
 }
 

--- a/src/contracts/composed_stream_template_unix.json
+++ b/src/contracts/composed_stream_template_unix.json
@@ -1,0 +1,2122 @@
+{
+  "name": "composed_stream_db_name",
+  "owner": "",
+  "extensions": null,
+  "tables": [
+    {
+      "name": "taxonomies",
+      "columns": [
+        {
+          "name": "taxonomy_id",
+          "type": {
+            "name": "uuid",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": [
+            {
+              "type": "PRIMARY_KEY",
+              "value": ""
+            },
+            {
+              "type": "NOT_NULL",
+              "value": ""
+            }
+          ]
+        },
+        {
+          "name": "child_stream_id",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": [
+            {
+              "type": "NOT_NULL",
+              "value": ""
+            }
+          ]
+        },
+        {
+          "name": "child_data_provider",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": [
+            {
+              "type": "NOT_NULL",
+              "value": ""
+            }
+          ]
+        },
+        {
+          "name": "weight",
+          "type": {
+            "name": "decimal",
+            "is_array": false,
+            "metadata": [
+              36,
+              18
+            ]
+          },
+          "attributes": [
+            {
+              "type": "NOT_NULL",
+              "value": ""
+            }
+          ]
+        },
+        {
+          "name": "created_at",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": [
+            {
+              "type": "NOT_NULL",
+              "value": ""
+            }
+          ]
+        },
+        {
+          "name": "disabled_at",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": null
+        },
+        {
+          "name": "version",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": [
+            {
+              "type": "NOT_NULL",
+              "value": ""
+            }
+          ]
+        },
+        {
+          "name": "start_date",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": null
+        }
+      ],
+      "indexes": null,
+      "foreign_keys": null
+    },
+    {
+      "name": "metadata",
+      "columns": [
+        {
+          "name": "row_id",
+          "type": {
+            "name": "uuid",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": [
+            {
+              "type": "PRIMARY_KEY",
+              "value": ""
+            },
+            {
+              "type": "NOT_NULL",
+              "value": ""
+            }
+          ]
+        },
+        {
+          "name": "metadata_key",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": [
+            {
+              "type": "NOT_NULL",
+              "value": ""
+            }
+          ]
+        },
+        {
+          "name": "value_i",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": null
+        },
+        {
+          "name": "value_f",
+          "type": {
+            "name": "decimal",
+            "is_array": false,
+            "metadata": [
+              36,
+              18
+            ]
+          },
+          "attributes": null
+        },
+        {
+          "name": "value_b",
+          "type": {
+            "name": "bool",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": null
+        },
+        {
+          "name": "value_s",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": null
+        },
+        {
+          "name": "value_ref",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": null
+        },
+        {
+          "name": "created_at",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": [
+            {
+              "type": "NOT_NULL",
+              "value": ""
+            }
+          ]
+        },
+        {
+          "name": "disabled_at",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": null
+        }
+      ],
+      "indexes": [
+        {
+          "name": "key_idx",
+          "columns": [
+            "metadata_key"
+          ],
+          "type": "BTREE"
+        },
+        {
+          "name": "ref_idx",
+          "columns": [
+            "value_ref"
+          ],
+          "type": "BTREE"
+        },
+        {
+          "name": "created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "type": "BTREE"
+        }
+      ],
+      "foreign_keys": null
+    }
+  ],
+  "actions": null,
+  "procedures": [
+    {
+      "name": "stream_exists",
+      "parameters": [
+        {
+          "name": "$data_provider",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$stream_id",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "$dbid text := get_dbid($data_provider, $stream_id);\n\n    for $row in SELECT * FROM get_metadata('type', true, null) {\n        return true;\n    }\n\n    return false;",
+      "return_types": {
+        "is_table": false,
+        "fields": [
+          {
+            "name": "result",
+            "type": {
+              "name": "bool",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "get_dbid",
+      "parameters": [
+        {
+          "name": "$data_provider",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$stream_id",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": false,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "$starts_with_0x bool := false;\n    for $row in SELECT $data_provider LIKE '0x%' as a {\n        $starts_with_0x := $row.a;\n    }\n\n    $data_provider_without_0x text;\n\n    if $starts_with_0x == true {\n        $data_provider_without_0x := substring($data_provider, 3);\n    } else {\n        $data_provider_without_0x := $data_provider;\n    }\n\n    return generate_dbid($stream_id, decode($data_provider_without_0x, 'hex'));",
+      "return_types": {
+        "is_table": false,
+        "fields": [
+          {
+            "name": "result",
+            "type": {
+              "name": "text",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "get_raw_record",
+      "parameters": [
+        {
+          "name": "$date_from",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$date_to",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$frozen_at",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$child_data_providers",
+          "type": {
+            "name": "text",
+            "is_array": true,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$child_stream_ids",
+          "type": {
+            "name": "text",
+            "is_array": true,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": false,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "if is_wallet_allowed_to_read(@caller) == false {\n        error('wallet not allowed to read');\n    }\n    // check if the stream is allowed to compose\n    is_stream_allowed_to_compose(@foreign_caller);\n\n    // check if the child_data_providers and child_stream_id are the same length\n    if array_length($child_data_providers) != array_length($child_stream_ids) {\n        error('child_data_providers and child_stream_id must be the same length');\n    }\n\n    if array_length($child_data_providers) \u003e 0 {\n        // arrays are 1-indexed, so we match that\n        for $taxonomy_index in 1..array_length($child_data_providers) {\n            $dbid text := get_dbid($child_data_providers[$taxonomy_index], $child_stream_ids[$taxonomy_index]);\n            for $row3 in SELECT * FROM ext_get_record[$dbid, 'get_record']($date_from, $date_to, $frozen_at) {\n                return next $row3.date_value, $row3.value, $taxonomy_index;\n            }\n        }\n    }",
+      "return_types": {
+        "is_table": true,
+        "fields": [
+          {
+            "name": "date_value",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          },
+          {
+            "name": "taxonomy_index",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "get_raw_index",
+      "parameters": [
+        {
+          "name": "$date_from",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$date_to",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$frozen_at",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$child_data_providers",
+          "type": {
+            "name": "text",
+            "is_array": true,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$child_stream_ids",
+          "type": {
+            "name": "text",
+            "is_array": true,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$base_date",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": false,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "if is_wallet_allowed_to_read(@caller) == false {\n        error('wallet not allowed to read');\n    }\n    // check if the stream is allowed to compose\n    is_stream_allowed_to_compose(@foreign_caller);\n\n    // check if the child_data_providers and child_stream_id are the same length\n    if array_length($child_data_providers) != array_length($child_stream_ids) {\n        error('child_data_providers and child_stream_id must be the same length');\n    }\n\n    if array_length($child_data_providers) \u003e 0 {\n        // arrays are 1-indexed, so we match that\n        for $taxonomy_index in 1..array_length($child_data_providers) {\n            $dbid text := get_dbid($child_data_providers[$taxonomy_index], $child_stream_ids[$taxonomy_index]);\n            for $row in SELECT * FROM ext_get_index[$dbid, 'get_index']($date_from, $date_to, $frozen_at, $base_date) {\n                return next $row.date_value, $row.value, $taxonomy_index;\n            }\n        }\n    }",
+      "return_types": {
+        "is_table": true,
+        "fields": [
+          {
+            "name": "date_value",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          },
+          {
+            "name": "taxonomy_index",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "get_record_filled",
+      "parameters": [
+        {
+          "name": "$date_from",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$date_to",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$frozen_at",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": false,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "$base_taxonomy_list int[];\n\n    // Initialize taxonomy variables\n    $taxonomy_count int := 0;\n    $last_values decimal(36,18)[];\n    $child_data_providers text[];\n    $child_stream_id text[];\n\n    // Fetch taxonomy details\n    for $row in SELECT * FROM describe_taxonomies(true) {\n        $taxonomy_count := $taxonomy_count + 1;\n        $base_taxonomy_list := array_append($base_taxonomy_list, $taxonomy_count);\n        $last_values := array_append($last_values, null::decimal(36,18));\n        $child_data_providers := array_append($child_data_providers, $row.child_data_provider);\n        $child_stream_id := array_append($child_stream_id, $row.child_stream_id);\n    }\n\n    $unemitted_taxonomies_for_date int[] := $base_taxonomy_list;\n    $removed_elements_count int := 0;\n    $prev_date int := 0;\n    $current_date int := 0;\n\n   // what could make this process easier:\n   // - use a map to store the last values, so we can easily check if a value is null\n   // - better manipulation of tables as objects, then we could modify a table to\n   //   fill forward without needing to return immediately on each loop\n\n    // Fetch raw records and emit values with dynamic weights\n    for $row_raw in SELECT * FROM get_raw_record($date_from, $date_to, $frozen_at, $child_data_providers, $child_stream_id) ORDER BY date_value, taxonomy_index {\n        $current_date := $row_raw.date_value;\n\n        // Fetch the dynamic weight based on the current date\n        $dynamic_weight decimal(36,18) := get_dynamic_weight($child_stream_id[$row_raw.taxonomy_index], $current_date);\n\n        // Emit filled values for previous date if date has changed\n        if $current_date != $prev_date {\n            if $prev_date != 0 {\n                for $unemitted_taxonomy in $unemitted_taxonomies_for_date {\n                    // TODO: remove this when we have slices or include if we have just index assignment\n                    // if $unemitted_taxonomy is distinct from null {\n\n                    if $last_values[$unemitted_taxonomy] is distinct from null {\n                        // Use the stored dynamic weight from the previous date\n                        $dynamic_weight_prev := get_dynamic_weight($child_stream_id[$unemitted_taxonomy], $prev_date);\n                        return next $prev_date, $last_values[$unemitted_taxonomy] * $dynamic_weight_prev, $dynamic_weight_prev;\n                    }\n                }\n                // Clear unemitted taxonomies for the new date\n                $unemitted_taxonomies_for_date := $base_taxonomy_list;\n                $removed_elements_count := 0;\n            }\n        }\n\n        // TODO: uncomment when we have index assignment\n        // $last_values[$row_raw.taxonomy_index] := $row_raw.value;\n\n        // Update the last values for the current date\n        $last_values := array_update_element($last_values, $row_raw.taxonomy_index, $row_raw.value);\n\n        // Emit current value with the dynamic weight\n        return next $current_date, $row_raw.value * $dynamic_weight, $dynamic_weight;\n\n        // Remove emitted taxonomy from the unemitted list\n        // we need to subtract the removed_elements_count because the array is shrinking\n        // TODO: we can improve it when we either can remove elements, or with array element assignment\n        $unemitted_taxonomies_for_date := remove_array_element($unemitted_taxonomies_for_date, $row_raw.taxonomy_index - $removed_elements_count);\n        $removed_elements_count := $removed_elements_count + 1;\n        // remove elements is not performant without slices. Then let's make the elements null for now\n        // $unemitted_taxonomies_for_date[$row_raw.taxonomy_index] := null;\n\n        $prev_date := $current_date;\n    }\n\n    // Emit filled values for the last date\n    if $prev_date != 0 {\n        if $taxonomy_count \u003e 0 {\n            for $unemitted_taxonomy2 in $unemitted_taxonomies_for_date {\n                if $last_values[$unemitted_taxonomy2] is distinct from null {\n                    // Fetch the correct dynamic weight for the last date\n                    $dynamic_weight_last := get_dynamic_weight($child_stream_id[$unemitted_taxonomy2], $prev_date);\n                    return next $prev_date, $last_values[$unemitted_taxonomy2] * $dynamic_weight_last, $dynamic_weight_last;\n                }\n            }\n        }\n    }",
+      "return_types": {
+        "is_table": true,
+        "fields": [
+          {
+            "name": "date_value",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value_with_weight",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          },
+          {
+            "name": "weight",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "get_index_filled",
+      "parameters": [
+        {
+          "name": "$date_from",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$date_to",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$frozen_at",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$base_date",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": false,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "$base_taxonomy_list int[];\n\n    // Initialize taxonomy variables\n    $taxonomy_count int := 0;\n    $last_values decimal(36,18)[];\n    $child_data_providers text[];\n    $child_stream_id text[];\n\n    // Fetch taxonomy details\n    for $row in SELECT * FROM describe_taxonomies(true) {\n        $taxonomy_count := $taxonomy_count + 1;\n        $base_taxonomy_list := array_append($base_taxonomy_list, $taxonomy_count);\n        $last_values := array_append($last_values, null::decimal(36,18));\n        $child_data_providers := array_append($child_data_providers, $row.child_data_provider);\n        $child_stream_id := array_append($child_stream_id, $row.child_stream_id);\n    }\n\n    $unemitted_taxonomies_for_date int[] := $base_taxonomy_list;\n    $removed_elements_count int := 0;\n    $prev_date int := 0;\n    $current_date int := 0;\n\n    // what could make this process easier:\n    // - use a map to store the last values, so we can easily check if a value is null\n    // - better manipulation of tables as objects, then we could modify a table to\n    //   fill forward without needing to return immediately on each loop\n\n    for $row_raw in SELECT * FROM get_raw_index($date_from, $date_to, $frozen_at, $child_data_providers, $child_stream_id, $base_date) ORDER BY date_value, taxonomy_index {\n        $current_date := $row_raw.date_value;\n\n        // Fetch the dynamic weight based on the current date\n        $dynamic_weight decimal(36,18) := get_dynamic_weight($child_stream_id[$row_raw.taxonomy_index], $current_date);\n\n        // Emit filled values for the previous date if the date has changed\n        if $current_date != $prev_date {\n            if $prev_date != 0 {\n                for $unemitted_taxonomy in $unemitted_taxonomies_for_date {\n                    if $last_values[$unemitted_taxonomy] is distinct from null {\n                        // TODO: remove this when we have slices or include if we have just index assignment\n                        // if $unemitted_taxonomy is distinct from null {\n\n                        // Use the stored dynamic weight from the previous date\n                        $dynamic_weight_prev := get_dynamic_weight($child_stream_id[$unemitted_taxonomy], $prev_date);\n                        return next $prev_date, $last_values[$unemitted_taxonomy] * $dynamic_weight_prev, $dynamic_weight_prev;\n                    }\n                }\n            }\n            // Clear unemitted taxonomies for the new date\n            $unemitted_taxonomies_for_date := $base_taxonomy_list;\n            $removed_elements_count := 0;\n        }\n\n        // TODO: uncomment when we have index assignment\n        // $last_values[$row_raw.taxonomy_index] := $row_raw.value;\n\n        // Update the last values for the current date\n        $last_values := array_update_element($last_values, $row_raw.taxonomy_index, $row_raw.value);\n\n        // Emit the current value with the dynamic weight\n        return next $current_date, $row_raw.value * $dynamic_weight, $dynamic_weight;\n\n        // Remove emitted taxonomy from the unemitted list\n        // TODO: we can improve it when we either can remove elements, or with array element assignment\n        $unemitted_taxonomies_for_date := remove_array_element($unemitted_taxonomies_for_date, $row_raw.taxonomy_index - $removed_elements_count);\n        $removed_elements_count := $removed_elements_count + 1;\n\n        // remove elements is not performant without slices. Then let's make the elements null for now\n        // $unemitted_taxonomies_for_date[$row_raw.taxonomy_index] := null;\n\n        $prev_date := $current_date;\n    }\n\n    // Emit filled values for the last date\n    if $prev_date != 0 {\n        if $taxonomy_count \u003e 0 {\n            for $unemitted_taxonomy2 in $unemitted_taxonomies_for_date {\n                if $last_values[$unemitted_taxonomy2] is distinct from null {\n                    // Fetch the correct dynamic weight for the last date\n                    $dynamic_weight_last := get_dynamic_weight($child_stream_id[$unemitted_taxonomy2], $prev_date);\n                    return next $prev_date, $last_values[$unemitted_taxonomy2] * $dynamic_weight_last, $dynamic_weight_last;\n                }\n            }\n        }\n    }",
+      "return_types": {
+        "is_table": true,
+        "fields": [
+          {
+            "name": "date_value",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value_with_weight",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          },
+          {
+            "name": "weight",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "get_record",
+      "parameters": [
+        {
+          "name": "$date_from",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$date_to",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$frozen_at",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "$in_range bool := false;\n    $last_date int;\n    $last_value decimal(36,18);\n    // here, we sum all of the records that were found by aggregating on the date_valie\n    for $row in SELECT date_value, total_value_with_weight / total_weight as value FROM\n        (SELECT\n            date_value,\n            SUM(value_with_weight)::decimal(36,18) AS total_value_with_weight,\n            SUM(weight)::decimal(36,18) AS total_weight\n        FROM get_record_filled($date_from, $date_to, $frozen_at) group by date_value) as r {\n        // when we arrive in the range, we start emitting. If there was a previous value, we emit it\n        if $in_range == false {\n            if $row.date_value \u003e= $date_from {\n                $in_range := true;\n                if ($last_date is distinct from null) AND $row.date_value != $date_from {\n                    return next $last_date, $last_value;\n                }\n            }\n\n            $last_date := $row.date_value;\n            $last_value := $row.value;\n        }\n        // we check again, because it might just have entered the range\n        if $in_range == true {\n            return next $row.date_value, $row.value;\n        }\n    }\n\n    // if we finished the loop and we never entered the range, we emit the last value\n    if $in_range == false AND $last_date is distinct from null {\n        return next $last_date, $last_value;\n    }",
+      "return_types": {
+        "is_table": true,
+        "fields": [
+          {
+            "name": "date_value",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "get_index",
+      "parameters": [
+        {
+          "name": "$date_from",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$date_to",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$frozen_at",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$base_date",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "$in_range bool := false;\n    $last_date int;\n    $last_value decimal(36,18);\n    $effective_base_date int := $base_date;\n\n    if $effective_base_date is null OR $effective_base_date == 0 {\n        for $v_row in SELECT * FROM get_metadata('default_base_date', true, null) ORDER BY created_at DESC LIMIT 1 {\n            $effective_base_date := $v_row.value_i;\n        }\n    }\n\n    // here, we sum all of the indexes that were found by aggregating on the date_value\n    for $row in SELECT date_value, total_value_with_weight / total_weight as value FROM\n        (SELECT\n            date_value,\n            SUM(value_with_weight)::decimal(36,18) AS total_value_with_weight,\n            SUM(weight)::decimal(36,18) AS total_weight\n        FROM get_index_filled($date_from, $date_to, $frozen_at, $effective_base_date) group by date_value) as r {\n        // when we arrive in the range, we start emitting. If there was a previous value, we emit it\n        if $in_range == false {\n            if $row.date_value \u003e= $date_from {\n                $in_range := true;\n                if ($last_date is distinct from null) AND $row.date_value != $date_from {\n                    return next $last_date, $last_value;\n                }\n            }\n\n            $last_date := $row.date_value;\n            $last_value := $row.value;\n        }\n        // we check again, because it might just have entered the range\n        if $in_range == true {\n            return next $row.date_value, $row.value;\n        }\n    }\n\n    // if we finished the loop and we never entered the range, we emit the last value\n    if $in_range == false AND $last_date is distinct from null {\n        return next $last_date, $last_value;\n    }",
+      "return_types": {
+        "is_table": true,
+        "fields": [
+          {
+            "name": "date_value",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "get_first_record",
+      "parameters": [
+        {
+          "name": "$after_date",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$frozen_at",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "if is_wallet_allowed_to_read(@caller) == false {\n        error('wallet not allowed to read');\n    }\n\n    // check compose access\n    is_stream_allowed_to_compose(@foreign_caller);\n\n    // let's coalesce null with ''\n    // then, if it's empty, it will always be the first value\n    if $after_date is null {\n        $after_date := 0;\n    }\n\n    // 1. figure the earliest date possible after the after_date\n   $earliest_date int := 0;\n   for $taxonomy_row in SELECT * FROM describe_taxonomies(true) {\n        $dbid := get_dbid($taxonomy_row.child_data_provider, $taxonomy_row.child_stream_id);\n        for $record_row in SELECT * FROM ext_get_first_record[$dbid, 'get_first_record']($after_date, $frozen_at) {\n            if $earliest_date == 0 OR $record_row.date_value \u003c $earliest_date {\n                $earliest_date := $record_row.date_value;\n            }\n        }\n   }\n\n   // 2. get_record with the earliest date if it exists\n   if $earliest_date != 0 {\n       for $row in SELECT date_value, value FROM get_record($earliest_date, $earliest_date, $frozen_at) {\n            return next $row.date_value, $row.value;\n       }\n   }",
+      "return_types": {
+        "is_table": true,
+        "fields": [
+          {
+            "name": "date_value",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "is_initiated",
+      "parameters": null,
+      "public": false,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "for $row in SELECT * FROM metadata WHERE metadata_key = 'type' LIMIT 1 {\n        return true;\n    }\n\n    return false;",
+      "return_types": {
+        "is_table": false,
+        "fields": [
+          {
+            "name": "result",
+            "type": {
+              "name": "bool",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "is_stream_owner",
+      "parameters": [
+        {
+          "name": "$wallet",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "for $row in SELECT * FROM metadata WHERE metadata_key = 'stream_owner' AND value_ref = LOWER($wallet) LIMIT 1 {\n        return true;\n    }\n    return false;",
+      "return_types": {
+        "is_table": false,
+        "fields": [
+          {
+            "name": "result",
+            "type": {
+              "name": "bool",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "is_wallet_allowed_to_read",
+      "parameters": [
+        {
+          "name": "$wallet",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "$visibility int := 0;\n    for $v_row in SELECT * FROM get_metadata('read_visibility', true, null) {\n        $visibility := $v_row.value_i;\n    }\n\n    if $visibility == 0 {\n        return true;\n    }\n\n    // if it's the owner, it's permitted\n    if is_stream_owner($wallet) {\n        return true;\n    }\n\n    // if there's metadata allow_read_wallet -\u003e \u003cwallet\u003e, then its permitted\n    for $row in SELECT * FROM get_metadata('allow_read_wallet', false, $wallet) {\n        return true;\n    }\n\n    return false;",
+      "return_types": {
+        "is_table": false,
+        "fields": [
+          {
+            "name": "value",
+            "type": {
+              "name": "bool",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "stream_owner_only",
+      "parameters": null,
+      "public": false,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "if is_stream_owner(@caller) == false  {\n        error('Stream owner only procedure');\n    }",
+      "return_types": null,
+      "annotations": null
+    },
+    {
+      "name": "init",
+      "parameters": null,
+      "public": true,
+      "modifiers": [
+        "OWNER"
+      ],
+      "body": "if is_initiated() {\n        error('this contract was already initialized');\n    }\n\n    // check if caller is empty\n    // this happens can happen in tests, but we should also protect for that on production\n    if @caller == '' {\n        error('caller is empty');\n    }\n\n    $current_block int := @height;\n\n    // uuid's namespaces are any random generated uuid from https://www.uuidtools.com/v5\n    // but each usage should be different to maintain determinism, so we reuse the previous result\n    $current_uuid uuid := uuid_generate_v5('41fea9f0-179f-11ef-8838-325096b39f47'::uuid, @txid);\n\n    // type = composed\n    $current_uuid :=  uuid_generate_v5($current_uuid, @txid);\n    INSERT INTO metadata (row_id, metadata_key, value_s, created_at)\n        VALUES ($current_uuid, 'type', 'composed', $current_block);\n\n    // stream_owner = @caller\n    $current_uuid :=  uuid_generate_v5($current_uuid, @txid);\n    INSERT INTO metadata (row_id, metadata_key, value_ref, created_at)\n        VALUES ($current_uuid, 'stream_owner', LOWER(@caller), 1);\n\n    // compose_visibility = 0 (public)\n    $current_uuid :=  uuid_generate_v5($current_uuid, @txid);\n    INSERT INTO metadata (row_id, metadata_key, value_i, created_at)\n        VALUES ($current_uuid, 'compose_visibility', 0, $current_block);\n\n    // read_visibility = 0 (public)\n    $current_uuid :=  uuid_generate_v5($current_uuid, @txid);\n    INSERT INTO metadata (row_id, metadata_key, value_i, created_at)\n        VALUES ($current_uuid, 'read_visibility', 0, $current_block);\n\n    $readonly_keys text[] := [\n        'type',\n        'stream_owner',\n        'readonly_key',\n        'taxonomy_version'\n    ];\n\n    for $key in $readonly_keys {\n        $current_uuid :=  uuid_generate_v5($current_uuid, @txid);\n        INSERT INTO metadata (row_id, metadata_key, value_s, created_at)\n            VALUES ($current_uuid, 'readonly_key', $key, $current_block);\n    }",
+      "return_types": null,
+      "annotations": null
+    },
+    {
+      "name": "insert_metadata",
+      "parameters": [
+        {
+          "name": "$key",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$value",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$val_type",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": null,
+      "body": "$value_i int;\n    $value_s text;\n    $value_f decimal(36,18);\n    $value_b bool;\n    $value_ref text;\n\n    if $val_type == 'int' {\n        $value_i := $value::int;\n    } elseif $val_type == 'string' {\n        $value_s := $value;\n    } elseif $val_type == 'bool' {\n        $value_b := $value::bool;\n    } elseif $val_type == 'ref' {\n        $value_ref := $value;\n    } elseif $val_type == 'float' {\n        $value_f := $value::decimal(36,18);\n    } else {\n        error(format('unknown type used \"%s\". valid types = \"float\" | \"bool\" | \"int\" | \"ref\" | \"string\"', $val_type));\n    }\n\n    stream_owner_only();\n\n    if is_initiated() == false {\n        error('contract must be initiated');\n    }\n\n    // check if it's read-only\n    for $row in SELECT * FROM metadata WHERE metadata_key = 'readonly_key' AND value_s = $key LIMIT 1 {\n        error('Cannot insert metadata for read-only key');\n    }\n\n    // we create one deterministic uuid for each metadata record\n    // we can't use just @txid because a single transaction can insert multiple metadata records.\n    // the result will be idempotency here too.\n    $uuid_key := @txid || $key || $value;\n\n    $uuid uuid := uuid_generate_v5('1361df5d-0230-47b3-b2c1-37950cf51fe9'::uuid, $uuid_key);\n    $current_block int := @height;\n\n    // insert data\n    INSERT INTO metadata (row_id, metadata_key, value_i, value_f, value_s, value_b, value_ref, created_at)\n        VALUES ($uuid, $key, $value_i, $value_f, $value_s, $value_b, LOWER($value_ref), $current_block);",
+      "return_types": null,
+      "annotations": null
+    },
+    {
+      "name": "get_metadata",
+      "parameters": [
+        {
+          "name": "$key",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$only_latest",
+          "type": {
+            "name": "bool",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$ref",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "if $only_latest == true {\n            if $ref is distinct from null {\n                return SELECT\n                              row_id,\n                              null::int as value_i,\n                              null::decimal(36,18) as value_f,\n                              null::bool as value_b,\n                              null::text as value_s,\n                              value_ref,\n                              created_at\n                FROM metadata\n                WHERE metadata_key = $key AND disabled_at IS NULL AND value_ref = LOWER($ref)\n                ORDER BY created_at DESC\n                LIMIT 1;\n            } else {\n                return SELECT\n                              row_id,\n                              value_i,\n                              value_f,\n                              value_b,\n                              value_s,\n                              value_ref,\n                              created_at\n                FROM metadata\n                WHERE metadata_key = $key AND disabled_at IS NULL\n                ORDER BY created_at DESC\n                LIMIT 1;\n            }\n        } else {\n           // SHOULD BE THE EXACT CODE AS ABOVE, BUT WITHOUT LIMIT\n           if $ref is distinct from null {\n               return SELECT\n                             row_id,\n                             null::int as value_i,\n                             null::decimal(36,18) as value_f,\n                             null::bool as value_b,\n                             null::text as value_s,\n                             value_ref,\n                             created_at\n                FROM metadata\n                WHERE metadata_key = $key AND disabled_at IS NULL AND value_ref = LOWER($ref)\n                ORDER BY created_at DESC;\n           } else {\n               return SELECT\n                             row_id,\n                             value_i,\n                             value_f,\n                             value_b,\n                             value_s,\n                             value_ref,\n                             created_at\n               FROM metadata\n               WHERE metadata_key = $key AND disabled_at IS NULL\n               ORDER BY created_at DESC;\n           }\n        }",
+      "return_types": {
+        "is_table": true,
+        "fields": [
+          {
+            "name": "row_id",
+            "type": {
+              "name": "uuid",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value_i",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value_f",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          },
+          {
+            "name": "value_b",
+            "type": {
+              "name": "bool",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value_s",
+            "type": {
+              "name": "text",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value_ref",
+            "type": {
+              "name": "text",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "created_at",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "disable_metadata",
+      "parameters": [
+        {
+          "name": "$row_id",
+          "type": {
+            "name": "uuid",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": null,
+      "body": "stream_owner_only();\n\n    $current_block int := @height;\n\n    $found bool := false;\n\n    // Check if the metadata is not read-only\n    for $metadata_row in\n    SELECT metadata_key\n    FROM metadata\n    WHERE row_id = $row_id AND disabled_at IS NULL\n    LIMIT 1 {\n        $found := true;\n        $row_key text := $metadata_row.metadata_key;\n\n        for $readonly_row in SELECT row_id FROM metadata WHERE metadata_key = 'readonly_key' AND value_s = $row_key LIMIT 1 {\n            error('Cannot disable read-only metadata');\n        }\n\n        UPDATE metadata SET disabled_at = $current_block\n        WHERE row_id = $row_id;\n    }\n\n    if $found == false {\n        error('metadata record not found');\n    }",
+      "return_types": null,
+      "annotations": null
+    },
+    {
+      "name": "transfer_stream_ownership",
+      "parameters": [
+        {
+          "name": "$new_owner",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": null,
+      "body": "stream_owner_only();\n\n    // fail if not a valid address\n    check_eth_address($new_owner);\n\n    UPDATE metadata SET value_ref = LOWER($new_owner)\n    WHERE metadata_key = 'stream_owner';",
+      "return_types": null,
+      "annotations": null
+    },
+    {
+      "name": "check_eth_address",
+      "parameters": [
+        {
+          "name": "$address",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": false,
+      "modifiers": null,
+      "body": "if (length($address) != 42) {\n        error('invalid address length');\n    }\n\n    // check if starts with 0x\n    for $row in SELECT $address LIKE '0x%' as a {\n        if $row.a == false {\n            error('address does not start with 0x');\n        }\n    }",
+      "return_types": null,
+      "annotations": null
+    },
+    {
+      "name": "get_current_version",
+      "parameters": [
+        {
+          "name": "$show_disabled",
+          "type": {
+            "name": "bool",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": false,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "if $show_disabled == false {\n         for $row in SELECT version FROM taxonomies WHERE disabled_at IS NULL ORDER BY version DESC LIMIT 1 {\n             return $row.version;\n         }\n    } else {\n        for $row2 in SELECT version FROM taxonomies ORDER BY version DESC LIMIT 1 {\n            return $row2.version;\n        }\n    }\n\n    return 0;",
+      "return_types": {
+        "is_table": false,
+        "fields": [
+          {
+            "name": "result",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "set_taxonomy",
+      "parameters": [
+        {
+          "name": "$data_providers",
+          "type": {
+            "name": "text",
+            "is_array": true,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$stream_ids",
+          "type": {
+            "name": "text",
+            "is_array": true,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$weights",
+          "type": {
+            "name": "decimal",
+            "is_array": true,
+            "metadata": [
+              36,
+              18
+            ]
+          }
+        },
+        {
+          "name": "$start_date",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": null,
+      "body": "stream_owner_only();\n\n    $next_version int := get_current_version(true) + 1;\n    $block_height int := @height;\n    $current_uuid uuid := uuid_generate_v5('e92064da-19c5-11ef-9bc0-325096b39f47'::uuid, @txid);\n\n    $length int := array_length($data_providers);\n\n    // check lengths\n    if $length != array_length($stream_ids) {\n        error('data_providers and stream_ids must have the same length');\n    }\n    if $length != array_length($weights) {\n        error('data_providers and weights must have the same length');\n    }\n\n    for $i in 1..$length {\n        $current_uuid :=  uuid_generate_v5($current_uuid, @txid);\n\n        INSERT INTO taxonomies (taxonomy_id, child_stream_id, child_data_provider, weight, created_at, version, start_date)\n            VALUES ($current_uuid, $stream_ids[$i], $data_providers[$i], $weights[$i], $block_height, $next_version, $start_date);\n    }",
+      "return_types": null,
+      "annotations": null
+    },
+    {
+      "name": "describe_taxonomies",
+      "parameters": [
+        {
+          "name": "$latest_version",
+          "type": {
+            "name": "bool",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "if $latest_version == true {\n            // just the latest enabled version should be returned\n            return SELECT\n                child_stream_id,\n                child_data_provider,\n                weight,\n                created_at,\n                version,\n                start_date\n            FROM taxonomies\n            WHERE version = get_current_version(false) AND disabled_at IS NULL\n            ORDER BY created_at DESC;\n        } else {\n            return SELECT\n                child_stream_id,\n                child_data_provider,\n                weight,\n                created_at,\n                version,\n                start_date\n            FROM taxonomies\n            WHERE disabled_at IS NULL\n            ORDER BY version DESC;\n        }",
+      "return_types": {
+        "is_table": true,
+        "fields": [
+          {
+            "name": "child_stream_id",
+            "type": {
+              "name": "text",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "child_data_provider",
+            "type": {
+              "name": "text",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "weight",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          },
+          {
+            "name": "created_at",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "version",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "start_date",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "disable_taxonomy",
+      "parameters": [
+        {
+          "name": "$version",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": null,
+      "body": "stream_owner_only();\n\n    $current_block int := @height;\n\n    $found bool := false;\n\n    // Check if the taxonomies with the given version exist and disable them\n    for $row in SELECT child_stream_id FROM taxonomies WHERE version = $version AND disabled_at IS NULL {\n        $found := true;\n        UPDATE taxonomies SET disabled_at = $current_block\n        WHERE version = $version AND disabled_at IS NULL;\n    }\n\n    if $found == false {\n        error('No taxonomies found for the given version');\n    }",
+      "return_types": null,
+      "annotations": null
+    },
+    {
+      "name": "is_stream_allowed_to_compose",
+      "parameters": [
+        {
+          "name": "$foreign_caller",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "if $foreign_caller == '' {\n        return true;\n    }\n\n    // if public, anyone can always read\n    // If there's no visibility metadata, it's public.\n    $visibility int := 0;\n    for $v_row in SELECT * FROM get_metadata('compose_visibility', true, null) {\n        $visibility := $v_row.value_i;\n    }\n\n    if $visibility == 0 {\n        return true;\n    }\n\n    // if there's metadata allow_compose_stream -\u003e \u003cforeign_caller\u003e, then its permitted\n    for $row in SELECT * FROM get_metadata('allow_compose_stream', true, $foreign_caller) LIMIT 1 {\n        return true;\n    }\n\n    error('Stream not allowed to compose');",
+      "return_types": {
+        "is_table": false,
+        "fields": [
+          {
+            "name": "value",
+            "type": {
+              "name": "bool",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "get_index_change",
+      "parameters": [
+        {
+          "name": "$date_from",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$date_to",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$frozen_at",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$base_date",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$days_interval",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "if $frozen_at == null {\n        $frozen_at := 0;\n    }\n\n    if $days_interval == null {\n        error('days_interval is required');\n    }\n\n    $current_values decimal(36,18)[];\n    // example: [01-2001, 05-2001, 09-2001, 10-2001]\n    $current_dates int[];\n    // example: [01-2000, 05-2000, 09-2000, 10-2000]\n    $expected_prev_dates int[];\n\n    for $row_current in SELECT * FROM get_index($date_from, $date_to, $frozen_at, $base_date) {\n        $prev_date := $row_current.date_value - ($days_interval * 86400);\n        $expected_prev_dates := array_append($expected_prev_dates, $prev_date);\n        $current_values := array_append($current_values, $row_current.value);\n        $current_dates := array_append($current_dates, $row_current.date_value);\n    }\n\n    // example: 01-2000]\n    $earliest_prev_date := $expected_prev_dates[1];\n    // example: 09-2000\n    $latest_prev_date := $expected_prev_dates[array_length($expected_prev_dates)];\n\n    // real previous values doesn't match the same length as expected previous dates\n    // because the interval can have much more values than the expected dates\n    $real_prev_values decimal(36,18)[];\n    $real_prev_dates int[];\n\n    // now we query the prev dates\n    for $row_prev in SELECT * FROM get_index($earliest_prev_date, $latest_prev_date, $frozen_at, $base_date) {\n        $real_prev_values := array_append($real_prev_values, $row_prev.value);\n        $real_prev_dates := array_append($real_prev_dates, $row_prev.date_value);\n    }\n\n    // now we calculate the matching dates for the real prev values\n    $result_prev_dates int[];\n    $result_prev_values decimal(36,18)[];\n\n    $real_prev_date_idx int := 1;\n\n    // for each expected prev date, we find the matching real prev date\n    if array_length($expected_prev_dates) \u003e 0 {\n        for $expected_prev_date_idx in 1..array_length($expected_prev_dates) {\n            // we start from the last index of real prev dates. we don't need to check previous values\n            for $selector in $real_prev_date_idx..array_length($real_prev_dates) {\n                // if next real prev date is greater than expected prev date (or null), then we need to use the current real value\n                if $real_prev_dates[$selector + 1] \u003e $expected_prev_dates[$expected_prev_date_idx] OR $real_prev_dates[$selector + 1] IS NULL {\n                    // if the current real prev date is already greater than expected prev date\n                    // we use NULL. We're probably before the first real prev date here\n                    if $real_prev_dates[$selector] \u003e $expected_prev_dates[$expected_prev_date_idx] {\n                        $result_prev_dates := array_append($result_prev_dates, null::int);\n                        $result_prev_values := array_append($result_prev_values, null::decimal(36,18));\n                    } else {\n                    $result_prev_dates := array_append($result_prev_dates, $real_prev_dates[$selector]);\n                    $result_prev_values := array_append($result_prev_values, $real_prev_values[$selector]);\n                    }\n                    // we already appended one for current $real_prev_date_idx, then we need to go to next\n                    $real_prev_date_idx := $selector;\n                    break;\n                }\n            }\n        }\n    }\n\n    // check if we have the same number of values and dates\n    if array_length($current_dates) != array_length($result_prev_dates) {\n        error('we have different number of dates and values');\n    }\n    if array_length($current_values) != array_length($result_prev_values) {\n        error('we have different number of dates and values');\n    }\n\n    // calculate the index change\n    if array_length($result_prev_dates) \u003e 0 {\n        for $row_result in 1..array_length($result_prev_dates) {\n            // if the expected_prev_date is null, then we don't have a real prev date\n            if $result_prev_dates[$row_result] IS DISTINCT FROM NULL {\n                return next $current_dates[$row_result], ($current_values[$row_result] - $result_prev_values[$row_result]) * 100.00::decimal(36,18) / $result_prev_values[$row_result];\n            }\n        }\n    }",
+      "return_types": {
+        "is_table": true,
+        "fields": [
+          {
+            "name": "date_value",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "emit_values_if",
+      "parameters": [
+        {
+          "name": "$condition",
+          "type": {
+            "name": "bool",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$date_value",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$values",
+          "type": {
+            "name": "decimal",
+            "is_array": true,
+            "metadata": [
+              36,
+              18
+            ]
+          }
+        },
+        {
+          "name": "$weights",
+          "type": {
+            "name": "decimal",
+            "is_array": true,
+            "metadata": [
+              36,
+              18
+            ]
+          }
+        }
+      ],
+      "public": false,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "if $condition == true {\n        if array_length($values) \u003e 0 {\n            for $i in 1..array_length($values) {\n                return next $date_value, $values[$i], $weights[$i];\n            }\n        }\n    }",
+      "return_types": {
+        "is_table": true,
+        "fields": [
+          {
+            "name": "date_value",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          },
+          {
+            "name": "weight",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "remove_array_element",
+      "parameters": [
+        {
+          "name": "$array",
+          "type": {
+            "name": "int",
+            "is_array": true,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$index",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": false,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "$new_array int[];\n    for $i in 1..array_length($array) {\n        if $i != $index {\n            $new_array := array_append($new_array, $array[$i]);\n        }\n    }\n\n    return $new_array;",
+      "return_types": {
+        "is_table": false,
+        "fields": [
+          {
+            "name": "result",
+            "type": {
+              "name": "int",
+              "is_array": true,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "array_update_element",
+      "parameters": [
+        {
+          "name": "$array",
+          "type": {
+            "name": "decimal",
+            "is_array": true,
+            "metadata": [
+              36,
+              18
+            ]
+          }
+        },
+        {
+          "name": "$index",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$value",
+          "type": {
+            "name": "decimal",
+            "is_array": false,
+            "metadata": [
+              36,
+              18
+            ]
+          }
+        }
+      ],
+      "public": false,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "$new_array decimal(36,18)[];\n    for $i in 1..array_length($array) {\n        if $i == $index {\n            $new_array := array_append($new_array, $value);\n        } else {\n            $new_array := array_append($new_array, $array[$i]);\n        }\n    }\n    return $new_array;",
+      "return_types": {
+        "is_table": false,
+        "fields": [
+          {
+            "name": "result",
+            "type": {
+              "name": "decimal",
+              "is_array": true,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "get_dynamic_weight",
+      "parameters": [
+        {
+          "name": "$stream_id",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$date_value",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": false,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "for $row in SELECT weight\n    FROM taxonomies\n    WHERE child_stream_id = $stream_id\n    AND (start_date IS NULL OR start_date = 0 OR start_date \u003c= $date_value)\n    ORDER BY start_date DESC\n    LIMIT 1 {\n        return $row.weight;\n    }\n\n    // If no weight is found, we return the earliest weight available, this to ensure that we always have a weight\n    // for the given date even if it's before the first weight's start_date\n    // Would be better if COALESCE was supported\n    for $row2 in SELECT weight\n    FROM taxonomies\n    WHERE child_stream_id = $stream_id\n    ORDER BY start_date ASC\n    LIMIT 1 {\n        return $row2.weight;\n    }",
+      "return_types": {
+        "is_table": false,
+        "fields": [
+          {
+            "name": "weight",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    }
+  ],
+  "foreign_calls": [
+    {
+      "name": "ext_get_record",
+      "parameters": [
+        {
+          "name": "int",
+          "is_array": false,
+          "metadata": [
+            0,
+            0
+          ]
+        },
+        {
+          "name": "int",
+          "is_array": false,
+          "metadata": [
+            0,
+            0
+          ]
+        },
+        {
+          "name": "int",
+          "is_array": false,
+          "metadata": [
+            0,
+            0
+          ]
+        }
+      ],
+      "return_types": {
+        "is_table": true,
+        "fields": [
+          {
+            "name": "date_value",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ext_get_index",
+      "parameters": [
+        {
+          "name": "int",
+          "is_array": false,
+          "metadata": [
+            0,
+            0
+          ]
+        },
+        {
+          "name": "int",
+          "is_array": false,
+          "metadata": [
+            0,
+            0
+          ]
+        },
+        {
+          "name": "int",
+          "is_array": false,
+          "metadata": [
+            0,
+            0
+          ]
+        },
+        {
+          "name": "int",
+          "is_array": false,
+          "metadata": [
+            0,
+            0
+          ]
+        }
+      ],
+      "return_types": {
+        "is_table": true,
+        "fields": [
+          {
+            "name": "date_value",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ext_get_first_record",
+      "parameters": [
+        {
+          "name": "int",
+          "is_array": false,
+          "metadata": [
+            0,
+            0
+          ]
+        },
+        {
+          "name": "int",
+          "is_array": false,
+          "metadata": [
+            0,
+            0
+          ]
+        }
+      ],
+      "return_types": {
+        "is_table": true,
+        "fields": [
+          {
+            "name": "date_value",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/contracts/contractsContent.ts
+++ b/src/contracts/contractsContent.ts
@@ -1,7 +1,9 @@
 import composedStreamTemplate from "./composed_stream_template.json" with { type: "json" };
 import primitiveStreamTemplate from "./primitive_stream_template.json" with { type: "json" };
+import composedStreamTemplateUnix from "./composed_stream_template_unix.json" with { type: "json" };
+import primitiveStreamTemplateUnix from "./primitive_stream_template_unix.json" with { type: "json" };
 
-export { composedStreamTemplate, primitiveStreamTemplate };
+export { composedStreamTemplate, primitiveStreamTemplate, composedStreamTemplateUnix, primitiveStreamTemplateUnix };
 
 if (import.meta.vitest) {
   const { describe, it, expect } = import.meta.vitest;
@@ -14,6 +16,16 @@ if (import.meta.vitest) {
     it("primitiveStreamTemplate", () => {
       expect(primitiveStreamTemplate).toBeDefined();
       expect(primitiveStreamTemplate.name).toBe("primitive_stream_db_name");
+    });
+
+    it("composedStreamTemplateUnix", () => {
+      expect(composedStreamTemplateUnix).toBeDefined();
+      expect(composedStreamTemplateUnix.name).toBe("composed_stream_db_name");
+    });
+
+    it("primitiveStreamTemplateUnix", () => {
+      expect(primitiveStreamTemplateUnix).toBeDefined();
+      expect(primitiveStreamTemplateUnix.name).toBe("primitive_stream_db_name");
     });
   });
 }

--- a/src/contracts/primitive_stream_template_unix.json
+++ b/src/contracts/primitive_stream_template_unix.json
@@ -1,0 +1,1173 @@
+{
+  "name": "primitive_stream_db_name",
+  "owner": "",
+  "extensions": null,
+  "tables": [
+    {
+      "name": "primitive_events",
+      "columns": [
+        {
+          "name": "date_value",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": [
+            {
+              "type": "NOT_NULL",
+              "value": ""
+            }
+          ]
+        },
+        {
+          "name": "value",
+          "type": {
+            "name": "decimal",
+            "is_array": false,
+            "metadata": [
+              36,
+              18
+            ]
+          },
+          "attributes": [
+            {
+              "type": "NOT_NULL",
+              "value": ""
+            }
+          ]
+        },
+        {
+          "name": "created_at",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": [
+            {
+              "type": "NOT_NULL",
+              "value": ""
+            }
+          ]
+        }
+      ],
+      "indexes": [
+        {
+          "name": "identifier_idx",
+          "columns": [
+            "date_value",
+            "created_at"
+          ],
+          "type": "PRIMARY"
+        }
+      ],
+      "foreign_keys": null
+    },
+    {
+      "name": "metadata",
+      "columns": [
+        {
+          "name": "row_id",
+          "type": {
+            "name": "uuid",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": [
+            {
+              "type": "PRIMARY_KEY",
+              "value": ""
+            },
+            {
+              "type": "NOT_NULL",
+              "value": ""
+            }
+          ]
+        },
+        {
+          "name": "metadata_key",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": [
+            {
+              "type": "NOT_NULL",
+              "value": ""
+            }
+          ]
+        },
+        {
+          "name": "value_i",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": null
+        },
+        {
+          "name": "value_f",
+          "type": {
+            "name": "decimal",
+            "is_array": false,
+            "metadata": [
+              36,
+              18
+            ]
+          },
+          "attributes": null
+        },
+        {
+          "name": "value_b",
+          "type": {
+            "name": "bool",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": null
+        },
+        {
+          "name": "value_s",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": null
+        },
+        {
+          "name": "value_ref",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": null
+        },
+        {
+          "name": "created_at",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": [
+            {
+              "type": "NOT_NULL",
+              "value": ""
+            }
+          ]
+        },
+        {
+          "name": "disabled_at",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          },
+          "attributes": null
+        }
+      ],
+      "indexes": [
+        {
+          "name": "key_idx",
+          "columns": [
+            "metadata_key"
+          ],
+          "type": "BTREE"
+        },
+        {
+          "name": "ref_idx",
+          "columns": [
+            "value_ref"
+          ],
+          "type": "BTREE"
+        },
+        {
+          "name": "created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "type": "BTREE"
+        }
+      ],
+      "foreign_keys": null
+    }
+  ],
+  "actions": null,
+  "procedures": [
+    {
+      "name": "is_initiated",
+      "parameters": null,
+      "public": false,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "for $row in SELECT * FROM metadata WHERE metadata_key = 'type' LIMIT 1 {\n        return true;\n    }\n\n    return false;",
+      "return_types": {
+        "is_table": false,
+        "fields": [
+          {
+            "name": "result",
+            "type": {
+              "name": "bool",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "is_stream_owner",
+      "parameters": [
+        {
+          "name": "$wallet",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "for $row in SELECT * FROM metadata WHERE metadata_key = 'stream_owner' AND value_ref = LOWER($wallet) LIMIT 1 {\n        return true;\n    }\n    return false;",
+      "return_types": {
+        "is_table": false,
+        "fields": [
+          {
+            "name": "result",
+            "type": {
+              "name": "bool",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "is_wallet_allowed_to_write",
+      "parameters": [
+        {
+          "name": "$wallet",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "if is_stream_owner($wallet) {\n        return true;\n    }\n\n    // if there's metadata allow_write_wallet -\u003e \u003cwallet\u003e, then its permitted\n    for $row in SELECT * FROM get_metadata('allow_write_wallet', false, $wallet) {\n        return true;\n    }\n\n    return false;",
+      "return_types": {
+        "is_table": false,
+        "fields": [
+          {
+            "name": "value",
+            "type": {
+              "name": "bool",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "is_wallet_allowed_to_read",
+      "parameters": [
+        {
+          "name": "$wallet",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "$visibility int := 0;\n    for $v_row in SELECT * FROM get_metadata('read_visibility', true, null) {\n        $visibility := $v_row.value_i;\n    }\n\n    if $visibility == 0 {\n        return true;\n    }\n\n    // if it's the owner, it's permitted\n    if is_stream_owner($wallet) {\n        return true;\n    }\n\n    // if there's metadata allow_read_wallet -\u003e \u003cwallet\u003e, then its permitted\n    for $row in SELECT * FROM get_metadata('allow_read_wallet', false, $wallet) {\n        return true;\n    }\n\n    return false;",
+      "return_types": {
+        "is_table": false,
+        "fields": [
+          {
+            "name": "value",
+            "type": {
+              "name": "bool",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "stream_owner_only",
+      "parameters": null,
+      "public": false,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "if is_stream_owner(@caller) == false  {\n        error('Stream owner only procedure');\n    }",
+      "return_types": null,
+      "annotations": null
+    },
+    {
+      "name": "init",
+      "parameters": null,
+      "public": true,
+      "modifiers": [
+        "OWNER"
+      ],
+      "body": "if is_initiated() {\n        error('this contract was already initialized');\n    }\n\n    // check if caller is empty\n    // this happens can happen in tests, but we should also protect for that on production\n    if @caller == '' {\n        error('caller is empty');\n    }\n\n    $current_block int := @height;\n\n    // uuid's namespaces are any random generated uuid from https://www.uuidtools.com/v5\n    // but each usage should be different to maintain determinism, so we reuse the previous result\n    $current_uuid uuid := uuid_generate_v5('111bfa42-17a2-11ef-bf03-325096b39f47'::uuid, @txid);\n\n    // type = primitive\n    $current_uuid :=  uuid_generate_v5($current_uuid, @txid);\n    INSERT INTO metadata (row_id, metadata_key, value_s, created_at)\n        VALUES ($current_uuid, 'type', 'primitive', $current_block);\n\n    // stream_owner = @caller\n    $current_uuid :=  uuid_generate_v5($current_uuid, @txid);\n    INSERT INTO metadata (row_id, metadata_key, value_ref, created_at)\n        VALUES ($current_uuid, 'stream_owner', LOWER(@caller), 1);\n\n    // compose_visibility = 0 (public)\n    $current_uuid :=  uuid_generate_v5($current_uuid, @txid);\n    INSERT INTO metadata (row_id, metadata_key, value_i, created_at)\n        VALUES ($current_uuid, 'compose_visibility', 0, $current_block);\n\n    // read_visibility = 0 (public)\n    $current_uuid :=  uuid_generate_v5($current_uuid, @txid);\n    INSERT INTO metadata (row_id, metadata_key, value_i, created_at)\n        VALUES ($current_uuid, 'read_visibility', 0, $current_block);\n\n    $readonly_keys text[] := [\n        'type',\n        'stream_owner',\n        'readonly_key'\n    ];\n\n    for $key in $readonly_keys {\n        $current_uuid :=  uuid_generate_v5($current_uuid, @txid);\n        INSERT INTO metadata (row_id, metadata_key, value_s, created_at)\n            VALUES ($current_uuid, 'readonly_key', $key, $current_block);\n    }",
+      "return_types": null,
+      "annotations": null
+    },
+    {
+      "name": "insert_metadata",
+      "parameters": [
+        {
+          "name": "$key",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$value",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$val_type",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": null,
+      "body": "$value_i int;\n    $value_s text;\n    $value_f decimal(36,18);\n    $value_b bool;\n    $value_ref text;\n\n    if $val_type == 'int' {\n        $value_i := $value::int;\n    } elseif $val_type == 'string' {\n        $value_s := $value;\n    } elseif $val_type == 'bool' {\n        $value_b := $value::bool;\n    } elseif $val_type == 'ref' {\n        $value_ref := $value;\n    } elseif $val_type == 'float' {\n        $value_f := $value::decimal(36,18);\n    } else {\n        error(format('unknown type used \"%s\". valid types = \"float\" | \"bool\" | \"int\" | \"ref\" | \"string\"', $val_type));\n    }\n\n    stream_owner_only();\n\n    if is_initiated() == false {\n        error('contract must be initiated');\n    }\n\n    // check if it's read-only\n    for $row in SELECT * FROM metadata WHERE metadata_key = 'readonly_key' AND value_s = $key LIMIT 1 {\n        error('Cannot insert metadata for read-only key');\n    }\n\n    // we create one deterministic uuid for each metadata record\n    // we can't use just @txid because a single transaction can insert multiple metadata records.\n    // the result will be idempotency here too.\n    $uuid_key := @txid || $key || $value;\n\n    $uuid uuid := uuid_generate_v5('1361df5d-0230-47b3-b2c1-37950cf51fe9'::uuid, $uuid_key);\n    $current_block int := @height;\n\n    // insert data\n    INSERT INTO metadata (row_id, metadata_key, value_i, value_f, value_s, value_b, value_ref, created_at)\n        VALUES ($uuid, $key, $value_i, $value_f, $value_s, $value_b, LOWER($value_ref), $current_block);",
+      "return_types": null,
+      "annotations": null
+    },
+    {
+      "name": "get_metadata",
+      "parameters": [
+        {
+          "name": "$key",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$only_latest",
+          "type": {
+            "name": "bool",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$ref",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "if $only_latest == true {\n            if $ref is distinct from null {\n                return SELECT\n                              row_id,\n                              null::int as value_i,\n                              null::decimal(36,18) as value_f,\n                              null::bool as value_b,\n                              null::text as value_s,\n                              value_ref,\n                              created_at\n                FROM metadata\n                WHERE metadata_key = $key AND disabled_at IS NULL AND value_ref = LOWER($ref)\n                ORDER BY created_at DESC\n                LIMIT 1;\n            } else {\n                return SELECT\n                              row_id,\n                              value_i,\n                              value_f,\n                              value_b,\n                              value_s,\n                              value_ref,\n                              created_at\n                FROM metadata\n                WHERE metadata_key = $key AND disabled_at IS NULL\n                ORDER BY created_at DESC\n                LIMIT 1;\n            }\n        } else {\n           // SHOULD BE THE EXACT CODE AS ABOVE, BUT WITHOUT LIMIT\n           if $ref is distinct from null {\n               return SELECT\n                             row_id,\n                             null::int as value_i,\n                             null::decimal(36,18) as value_f,\n                             null::bool as value_b,\n                             null::text as value_s,\n                             value_ref,\n                             created_at\n                FROM metadata\n                WHERE metadata_key = $key AND disabled_at IS NULL AND value_ref = LOWER($ref)\n                ORDER BY created_at DESC;\n           } else {\n               return SELECT\n                             row_id,\n                             value_i,\n                             value_f,\n                             value_b,\n                             value_s,\n                             value_ref,\n                             created_at\n               FROM metadata\n               WHERE metadata_key = $key AND disabled_at IS NULL\n               ORDER BY created_at DESC;\n           }\n        }",
+      "return_types": {
+        "is_table": true,
+        "fields": [
+          {
+            "name": "row_id",
+            "type": {
+              "name": "uuid",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value_i",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value_f",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          },
+          {
+            "name": "value_b",
+            "type": {
+              "name": "bool",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value_s",
+            "type": {
+              "name": "text",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value_ref",
+            "type": {
+              "name": "text",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "created_at",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "disable_metadata",
+      "parameters": [
+        {
+          "name": "$row_id",
+          "type": {
+            "name": "uuid",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": null,
+      "body": "stream_owner_only();\n\n    $current_block int := @height;\n\n    $found bool := false;\n\n    // Check if the metadata is not read-only\n    for $metadata_row in\n    SELECT metadata_key\n    FROM metadata\n    WHERE row_id = $row_id AND disabled_at IS NULL\n    LIMIT 1 {\n        $found := true;\n        $row_key text := $metadata_row.metadata_key;\n\n        for $readonly_row in SELECT row_id FROM metadata WHERE metadata_key = 'readonly_key' AND value_s = $row_key LIMIT 1 {\n            error('Cannot disable read-only metadata');\n        }\n\n        UPDATE metadata SET disabled_at = $current_block\n        WHERE row_id = $row_id;\n    }\n\n    if $found == false {\n        error('metadata record not found');\n    }",
+      "return_types": null,
+      "annotations": null
+    },
+    {
+      "name": "insert_record",
+      "parameters": [
+        {
+          "name": "$date_value",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$value",
+          "type": {
+            "name": "decimal",
+            "is_array": false,
+            "metadata": [
+              36,
+              18
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": null,
+      "body": "if is_wallet_allowed_to_write(@caller) == false {\n        error('wallet not allowed to write');\n    }\n\n    if is_initiated() == false {\n        error('contract must be initiated');\n    }\n\n    $current_block int := @height;\n\n    // insert data\n    INSERT INTO primitive_events (date_value, value, created_at)\n        VALUES ($date_value, $value, $current_block);",
+      "return_types": null,
+      "annotations": null
+    },
+    {
+      "name": "get_index",
+      "parameters": [
+        {
+          "name": "$date_from",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$date_to",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$frozen_at",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$base_date",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "$effective_base_date int := $base_date;\n    if ($effective_base_date == 0 OR $effective_base_date IS NULL) {\n        for $v_row in SELECT * FROM get_metadata('default_base_date', true, null) ORDER BY created_at DESC LIMIT 1 {\n            $effective_base_date := $v_row.value_i;\n        }\n    }\n\n    $baseValue decimal(36,18) := get_base_value($effective_base_date, $frozen_at);\n    if $baseValue == 0::decimal(36,18) {\n        error('base value is 0');\n    }\n\n    return SELECT date_value, (value * 100::decimal(36,18)) / $baseValue as value FROM get_record($date_from, $date_to, $frozen_at);",
+      "return_types": {
+        "is_table": true,
+        "fields": [
+          {
+            "name": "date_value",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "get_base_value",
+      "parameters": [
+        {
+          "name": "$base_date",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$frozen_at",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": false,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "if $base_date is null OR $base_date = 0 {\n        for $row in SELECT * FROM primitive_events WHERE (created_at \u003c= $frozen_at OR $frozen_at = 0 OR $frozen_at IS NULL) ORDER BY date_value ASC, created_at DESC LIMIT 1 {\n            return $row.value;\n        }\n    }\n\n    for $row2 in SELECT * FROM primitive_events WHERE date_value \u003c= $base_date AND (created_at \u003c= $frozen_at OR $frozen_at = 0 OR $frozen_at IS NULL) ORDER BY date_value DESC, created_at DESC LIMIT 1 {\n        return $row2.value;\n    }\n\n    // if no value is found, we find the first value after the given date\n    // This will raise a red flag in the system and the data will undergo the usual process for when a new data provider is added.\n    for $row3 in SELECT * FROM primitive_events WHERE date_value \u003e $base_date AND (created_at \u003c= $frozen_at OR $frozen_at = 0 OR $frozen_at IS NULL) ORDER BY date_value ASC, created_at DESC LIMIT 1 {\n        return $row3.value;\n    }\n\n    // if no value is found, we return an error\n    error('no base value found');",
+      "return_types": {
+        "is_table": false,
+        "fields": [
+          {
+            "name": "value",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "get_first_record",
+      "parameters": [
+        {
+          "name": "$after_date",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$frozen_at",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "if is_wallet_allowed_to_read(@caller) == false {\n        error('wallet not allowed to read');\n    }\n\n    // check compose access\n    is_stream_allowed_to_compose(@foreign_caller);\n\n    // let's coalesce after_date with ''\n    // then, if it's empty, it will always be the first value\n    if $after_date is null {\n        $after_date := 0;\n    }\n\n    // coalesce frozen_at with 0\n    if $frozen_at is null {\n        $frozen_at := 0;\n    }\n\n    return SELECT date_value, value FROM primitive_events WHERE date_value \u003e= $after_date AND (created_at \u003c= $frozen_at OR $frozen_at = 0 OR $frozen_at IS NULL) ORDER BY date_value ASC, created_at DESC LIMIT 1;",
+      "return_types": {
+        "is_table": true,
+        "fields": [
+          {
+            "name": "date_value",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "get_original_record",
+      "parameters": [
+        {
+          "name": "$date_from",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$date_to",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$frozen_at",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": false,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "if is_wallet_allowed_to_read(@caller) == false {\n        error('wallet not allowed to read');\n    }\n    // check compose access\n    is_stream_allowed_to_compose(@foreign_caller);\n\n    $frozenValue int := 0;\n    if $frozen_at IS DISTINCT FROM NULL {\n        $frozenValue := $frozen_at::int;\n    }\n\n    // TODO: whereClause here is a placeholder only, not supported yet, but it will make things cleaner if it available\n    //$whereClause text := 'WHERE 1=1 ';\n    //if $date_from != '' {\n    //    $whereClause := $whereClause || 'AND date_value \u003e= $date_from ';\n    //}\n\n    //if $date_to != '' {\n    //    $whereClause := $whereClause || 'AND date_value \u003c= $date_to ';\n    //}\n\n\n    // TODO: Normally we would use the following query to get the latest value of each date\n    // But it's not working for JOIN and MAX() function\n    //for $row in SELECT date_value, value FROM primitive_events JOIN (SELECT date_value, MAX(created_at) as created_at FROM primitive_events GROUP BY date_value) as max_created\n    //ON primitive_events.date_value = max_created.date_value AND primitive_events.created_at = max_created.created_at\n    //$whereClause\n    //ORDER BY date_value DESC {\n    //    return next $row.date_value, $row.value;\n    //}\n\n   // TODO: had to use this workaround because \u0026\u0026 operator is not working\n   $last_result_date int := 0;\n   if $date_from IS DISTINCT FROM NULL {\n       if $date_to IS DISTINCT FROM NULL {\n           // date_from and date_to are provided\n           // we will fetch all records from date_from to date_to\n           for $row in SELECT date_value, value FROM primitive_events\n               WHERE date_value \u003e= $date_from AND date_value \u003c= $date_to\n               AND (created_at \u003c= $frozenValue OR $frozenValue = 0)\n               AND $last_result_date != date_value\n               ORDER BY date_value DESC, created_at DESC {\n                   if $last_result_date != $row.date_value {\n                        $last_result_date := $row.date_value;\n                       return next $row.date_value, $row.value;\n                   }\n               }\n       } else {\n           // only date_from is provided\n           // we will fetch all records from date_from to the latest\n           for $row2 in SELECT date_value, value FROM primitive_events\n               WHERE date_value \u003e= $date_from\n               AND (created_at \u003c= $frozenValue OR $frozenValue = 0)\n               AND $last_result_date != date_value\n               ORDER BY date_value DESC, created_at DESC {\n                   if $last_result_date != $row2.date_value {\n                        $last_result_date := $row2.date_value;\n                       return next $row2.date_value, $row2.value;\n                   }\n               }\n        }\n   } else {\n       if $date_to IS NOT DISTINCT FROM NULL {\n           // no date_from and date_to provided\n           // we fetch only the latest record\n           return SELECT date_value, value FROM primitive_events\n               WHERE created_at \u003c= $frozenValue OR $frozenValue = 0\n               AND $last_result_date != date_value\n               ORDER BY date_value DESC, created_at DESC LIMIT 1;\n       } else {\n           // date_to is provided but date_from is not\n           error('date_from is required if date_to is provided');\n       }\n   }",
+      "return_types": {
+        "is_table": true,
+        "fields": [
+          {
+            "name": "date_value",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "get_record",
+      "parameters": [
+        {
+          "name": "$date_from",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$date_to",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$frozen_at",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "$is_first_result bool := true;\n\n    for $row in SELECT * FROM get_original_record($date_from, $date_to, $frozen_at) {\n        // we will only fetch the last record before the first result\n        // if the first result is not the same as the start date\n        if $is_first_result == true {\n            $first_result_date int := $row.date_value;\n\n            // if the first result date is not the same as the start date, then we need to fetch the last record before it\n            if $first_result_date != $date_from {\n                for $last_row in SELECT * FROM get_last_record_before_date($first_result_date) {\n                    // Note: although the user requested a date_from, we are returning the previous date here\n                    // e.g., the user used date_from:2021-01-02, and we are returning 2021-01-01 as first value\n                    //\n                    // that happens because the accuracy is guaranteed with this behavior, otherwise the\n                    // user won't be able to know when a data point really exist in our database or not.\n\n                    return next $last_row.date_value, $last_row.value;\n                }\n            }\n\n            $is_first_result := false;\n        }\n\n        return next $row.date_value, $row.value;\n    }\n\n    // it's still the first result? i.e. there were no results\n    // so let's try finding the last record before the start date\n    if $is_first_result == true {\n        for $last_row2 in SELECT * FROM get_last_record_before_date($date_from) {\n            return next $last_row2.date_value, $last_row2.value;\n        }\n    }",
+      "return_types": {
+        "is_table": true,
+        "fields": [
+          {
+            "name": "date_value",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "get_last_record_before_date",
+      "parameters": [
+        {
+          "name": "$date_from",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "return SELECT date_value, value FROM primitive_events WHERE date_value \u003c $date_from ORDER BY date_value DESC, created_at DESC LIMIT 1;",
+      "return_types": {
+        "is_table": true,
+        "fields": [
+          {
+            "name": "date_value",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "transfer_stream_ownership",
+      "parameters": [
+        {
+          "name": "$new_owner",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": null,
+      "body": "stream_owner_only();\n\n    // fail if not a valid address\n    check_eth_address($new_owner);\n\n    UPDATE metadata SET value_ref = LOWER($new_owner)\n    WHERE metadata_key = 'stream_owner';",
+      "return_types": null,
+      "annotations": null
+    },
+    {
+      "name": "check_eth_address",
+      "parameters": [
+        {
+          "name": "$address",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": false,
+      "modifiers": null,
+      "body": "if (length($address) != 42) {\n        error('invalid address length');\n    }\n\n    // check if starts with 0x\n    for $row in SELECT $address LIKE '0x%' as a {\n        if $row.a == false {\n            error('address does not start with 0x');\n        }\n    }",
+      "return_types": null,
+      "annotations": null
+    },
+    {
+      "name": "is_stream_allowed_to_compose",
+      "parameters": [
+        {
+          "name": "$foreign_caller",
+          "type": {
+            "name": "text",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "if $foreign_caller == '' {\n        return true;\n    }\n\n    // if public, anyone can always read\n    // If there's no visibility metadata, it's public.\n    $visibility int := 0;\n    for $v_row in SELECT * FROM get_metadata('compose_visibility', true, null) {\n        $visibility := $v_row.value_i;\n    }\n\n    if $visibility == 0 {\n        return true;\n    }\n\n    // if there's metadata allow_compose_stream -\u003e \u003cforeign_caller\u003e, then its permitted\n    for $row in SELECT * FROM get_metadata('allow_compose_stream', true, $foreign_caller) LIMIT 1 {\n        return true;\n    }\n\n    error('stream not allowed to compose');",
+      "return_types": {
+        "is_table": false,
+        "fields": [
+          {
+            "name": "value",
+            "type": {
+              "name": "bool",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    },
+    {
+      "name": "get_index_change",
+      "parameters": [
+        {
+          "name": "$date_from",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$date_to",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$frozen_at",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$base_date",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "name": "$days_interval",
+          "type": {
+            "name": "int",
+            "is_array": false,
+            "metadata": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "public": true,
+      "modifiers": [
+        "VIEW"
+      ],
+      "body": "if $frozen_at == null {\n        $frozen_at := 0;\n    }\n\n    if $days_interval == null {\n        error('days_interval is required');\n    }\n\n    $current_values decimal(36,18)[];\n    // example: [01-2001, 05-2001, 09-2001, 10-2001]\n    $current_dates int[];\n    // example: [01-2000, 05-2000, 09-2000, 10-2000]\n    $expected_prev_dates int[];\n\n    for $row_current in SELECT * FROM get_index($date_from, $date_to, $frozen_at, $base_date) {\n        $prev_date := $row_current.date_value - ($days_interval * 86400);\n        $expected_prev_dates := array_append($expected_prev_dates, $prev_date);\n        $current_values := array_append($current_values, $row_current.value);\n        $current_dates := array_append($current_dates, $row_current.date_value);\n    }\n\n    // example: 01-2000]\n    $earliest_prev_date := $expected_prev_dates[1];\n    // example: 09-2000\n    $latest_prev_date := $expected_prev_dates[array_length($expected_prev_dates)];\n\n    // real previous values doesn't match the same length as expected previous dates\n    // because the interval can have much more values than the expected dates\n    $real_prev_values decimal(36,18)[];\n    $real_prev_dates int[];\n\n    // now we query the prev dates\n    for $row_prev in SELECT * FROM get_index($earliest_prev_date, $latest_prev_date, $frozen_at, $base_date) {\n        $real_prev_values := array_append($real_prev_values, $row_prev.value);\n        $real_prev_dates := array_append($real_prev_dates, $row_prev.date_value);\n    }\n\n    // now we calculate the matching dates for the real prev values\n    $result_prev_dates int[];\n    $result_prev_values decimal(36,18)[];\n\n    $real_prev_date_idx int := 1;\n\n    // for each expected prev date, we find the matching real prev date\n    if array_length($expected_prev_dates) \u003e 0 {\n        for $expected_prev_date_idx in 1..array_length($expected_prev_dates) {\n            // we start from the last index of real prev dates. we don't need to check previous values\n            for $selector in $real_prev_date_idx..array_length($real_prev_dates) {\n                // if next real prev date is greater than expected prev date (or null), then we need to use the current real value\n                if $real_prev_dates[$selector + 1] \u003e $expected_prev_dates[$expected_prev_date_idx]\n                   OR $real_prev_dates[$selector + 1] IS NULL {\n                    // if the current real prev date is already greater than expected prev date\n                    // we use NULL. We're probably before the first real prev date here\n                    if $real_prev_dates[$selector] \u003e $expected_prev_dates[$expected_prev_date_idx] {\n                        $result_prev_dates := array_append($result_prev_dates, null::int);\n                        $result_prev_values := array_append($result_prev_values, null::decimal(36,18));\n                    } else {\n                        $result_prev_dates := array_append($result_prev_dates, $real_prev_dates[$selector]);\n                        $result_prev_values := array_append($result_prev_values, $real_prev_values[$selector]);\n                    }\n                    // we already appended one for current $real_prev_date_idx, then we need to go to next\n                    $real_prev_date_idx := $selector;\n                    break;\n                }\n            }\n        }\n    }\n\n    // check if we have the same number of values and dates\n    if array_length($current_dates) != array_length($result_prev_dates) {\n        error('we have different number of dates and values');\n    }\n    if array_length($current_values) != array_length($result_prev_values) {\n        error('we have different number of dates and values');\n    }\n\n    // calculate the index change\n    if array_length($result_prev_dates) \u003e 0 {\n        for $row_result in 1..array_length($result_prev_dates) {\n            // if the expected_prev_date is null, then we don't have a real prev date\n            if $result_prev_dates[$row_result] IS DISTINCT FROM NULL {\n                return next $current_dates[$row_result], ($current_values[$row_result] - $result_prev_values[$row_result]) * 100.00::decimal(36,18) / $result_prev_values[$row_result];\n            }\n        }\n    }",
+      "return_types": {
+        "is_table": true,
+        "fields": [
+          {
+            "name": "date_value",
+            "type": {
+              "name": "int",
+              "is_array": false,
+              "metadata": [
+                0,
+                0
+              ]
+            }
+          },
+          {
+            "name": "value",
+            "type": {
+              "name": "decimal",
+              "is_array": false,
+              "metadata": [
+                36,
+                18
+              ]
+            }
+          }
+        ]
+      },
+      "annotations": null
+    }
+  ],
+  "foreign_calls": null
+}

--- a/tests/integration/composedStream.test.ts
+++ b/tests/integration/composedStream.test.ts
@@ -26,6 +26,11 @@ describe.sequential(
 
         const allStreamIds = [composedStreamId, childAStreamId, childBStreamId];
 
+        // Drop the stream if it already exists
+        for (const streamId of allStreamIds) {
+          await defaultClient.destroyStream(streamId, true).catch(() => {});
+        }
+
         try {
           // Deploy child streams with initial data
           // Child A: [2020-01-01: 1, 2020-01-02: 2, 2020-01-30: 3, 2020-02-01: 4, 2020-02-02: 5]
@@ -140,6 +145,143 @@ describe.sequential(
         }
       },
     );
+
+    testWithDefaultWallet(
+        "should deploy, initialize and use a composed stream with contract version 2",
+        async ({ defaultClient }) => {
+          // Generate unique stream IDs for composed and child streams
+          const composedStreamId = await StreamId.generate(
+              "test-composed-stream-v2",
+          );
+          const childAStreamId = await StreamId.generate(
+              "test-composed-stream-child-a-v2",
+          );
+          const childBStreamId = await StreamId.generate(
+              "test-composed-stream-child-b-v2",
+          );
+
+          const allStreamIds = [composedStreamId, childAStreamId, childBStreamId];
+
+          // Drop the stream if it already exists
+          for (const streamId of allStreamIds) {
+              await defaultClient.destroyStream(streamId, true).catch(() => {});
+          }
+
+          try {
+            // Deploy child streams with initial data
+            // Child A: [1: 1, 2: 2, 3: 3, 4: 4, 5: 5]
+            await deployPrimitiveStreamWithData(defaultClient, childAStreamId, [
+              { dateValue: 1, value: "1.000000000000000000" },
+              { dateValue: 2, value: "2.000000000000000000" },
+              { dateValue: 3, value: "3.000000000000000000" },
+              { dateValue: 4, value: "4.000000000000000000" },
+              { dateValue: 5, value: "5.000000000000000000" },
+            ], 2);
+
+            // Child B: [1: 3, 2: 4, 3: 5, 4: 6, 5: 7]
+            await deployPrimitiveStreamWithData(defaultClient, childBStreamId, [
+              { dateValue: 1, value: "3.000000000000000000" },
+              { dateValue: 2, value: "4.000000000000000000" },
+              { dateValue: 3, value: "5.000000000000000000" },
+              { dateValue: 4, value: "6.000000000000000000" },
+              { dateValue: 5, value: "7.000000000000000000" },
+            ], 2);
+
+            // Deploy composed stream
+            const deployReceipt = await defaultClient.deployStream(
+                composedStreamId,
+                "composed",
+                true,
+                2,
+            );
+            expect(deployReceipt.status).toBe(200);
+
+            // Load the composed stream
+            const composedStream = defaultClient.loadComposedStream({
+              streamId: composedStreamId,
+              dataProvider: defaultClient.address(),
+            });
+
+            // Initialize the composed stream
+            const initTx = await composedStream.initializeStream();
+            if (!initTx.data?.tx_hash) {
+              throw new Error("Init tx hash not found");
+            }
+            await defaultClient.waitForTx(initTx.data.tx_hash);
+
+            // Set taxonomy with weights
+            // Child A weight: 1, Child B weight: 2
+            const setTaxonomyTx = await composedStream.setTaxonomy({
+              taxonomyItems: [
+                {
+                  childStream: {
+                    streamId: childAStreamId,
+                    dataProvider: defaultClient.address(),
+                  },
+                  weight: "1",
+                },
+                {
+                  childStream: {
+                    streamId: childBStreamId,
+                    dataProvider: defaultClient.address(),
+                  },
+                  weight: "2",
+                },
+              ],
+              startDate: 3,
+            });
+            if (!setTaxonomyTx.data?.tx_hash) {
+              throw new Error("Set taxonomy tx hash not found");
+            }
+            await defaultClient.waitForTx(setTaxonomyTx.data.tx_hash);
+
+            // Verify taxonomies
+            const taxonomies = await composedStream.describeTaxonomies({
+              latestVersion: true,
+            });
+            expect(taxonomies.length).toBe(1);
+            expect(taxonomies[0].startDate).toBe(3);
+            expect(taxonomies[0].taxonomyItems.length).toBe(2);
+
+            // Query records after the taxonomy start date
+            const records = await composedStream.getRecord({
+              dateFrom: 4,
+              dateTo: 5,
+            });
+
+            // Verify records
+            // Formula: (value_A * weight_A + value_B * weight_B) / (weight_A + weight_B)
+            // 2020-02-01: (4 * 1 + 6 * 2) / (1 + 2) = 5.333...
+            // 2020-02-02: (5 * 1 + 7 * 2) / (1 + 2) = 6.333...
+            expect(records.length).toBe(2);
+            expect(parseFloat(records[0].value)).toBeCloseTo(5.333333, 5);
+            expect(parseFloat(records[1].value)).toBeCloseTo(6.333333, 5);
+
+            // Query index values
+            const index = await composedStream.getIndex({
+              dateFrom: 3,
+              dateTo: 4,
+              baseDate: 3,
+            });
+
+            // Verify index values
+            expect(index.length).toBe(2);
+            expect(parseFloat(index[0].value)).toBe(100); // Base date is always 100
+            expect(parseFloat(index[1].value)).toBeCloseTo(124.444444, 5); // Percentage change from base date
+
+            // Query first record
+            const firstRecord = await composedStream.getFirstRecord({});
+            expect(firstRecord).not.toBeNull();
+            expect(parseFloat(firstRecord!.value)).toBeCloseTo(2.333333, 5);
+            expect(firstRecord!.dateValue).toBe(1);
+          } finally {
+            // Cleanup: destroy all streams
+            for (const streamId of allStreamIds) {
+              await defaultClient.destroyStream(streamId, true).catch(() => {});
+            }
+          }
+        },
+    );
   },
 );
 
@@ -147,10 +289,11 @@ describe.sequential(
 async function deployPrimitiveStreamWithData(
   client: NodeTNClient,
   streamId: StreamId,
-  data: { dateValue: string; value: string }[],
+  data: { dateValue: string | number; value: string }[],
+  contractVersion?: number,
 ) {
   // Deploy primitive stream
-  const deployReceipt = await client.deployStream(streamId, "primitive", true);
+  const deployReceipt = await client.deployStream(streamId, "primitive", true, contractVersion);
   expect(deployReceipt.status).toBe(200);
 
   // Load and initialize the stream

--- a/tests/integration/primitiveStream.test.ts
+++ b/tests/integration/primitiveStream.test.ts
@@ -91,7 +91,7 @@ describe.sequential(
           // Cleanup: destroy the stream after test
           await defaultClient.destroyStream(streamId, true);
         }
-      },
+      }, 60000,
     );
 
     testWithDefaultWallet(
@@ -155,7 +155,96 @@ describe.sequential(
           // Cleanup
           await defaultClient.destroyStream(streamId, true);
         }
-      },
+      }, 60000,
+    );
+
+    testWithDefaultWallet(
+        "should deploy, initialize, write to, and read from a primitive stream version 2",
+        async ({ defaultClient }) => {
+          // Generate a unique stream ID
+          const streamId = await StreamId.generate("test-primitive-stream-v2");
+
+          // Destroy the stream if it already exists
+          await defaultClient.destroyStream(streamId, true).catch(() => {});
+
+          try {
+            // Deploy a primitive stream
+            const deployReceipt = await defaultClient.deployStream(
+                streamId,
+                "primitive",
+                true,
+                2,
+            );
+            expect(deployReceipt.status).toBe(200);
+
+            // Load the deployed stream
+            const primitiveStream = defaultClient.loadPrimitiveStream({
+              streamId,
+              dataProvider: defaultClient.address(),
+            });
+
+            // Initialize the stream
+            const initTx = await primitiveStream.initializeStream();
+            if (!initTx.data?.tx_hash) {
+              throw new Error("Init tx hash not found");
+            }
+            await defaultClient.waitForTx(initTx.data.tx_hash);
+
+            // Insert a record
+            const insertTx = await primitiveStream.insertRecords([
+              { dateValue: 1, value: "1" },
+            ]);
+            if (!insertTx.data?.tx_hash) {
+              throw new Error("Insert tx hash not found");
+            }
+            await defaultClient.waitForTx(insertTx.data.tx_hash);
+
+            // Query records
+            const records = await primitiveStream.getRecord({
+              dateFrom: 1,
+              dateTo: 1,
+            });
+
+            // Verify record content
+            expect(records.length).toBe(1);
+            expect(records[0].value).toBe("1.000000000000000000");
+            expect(records[0].dateValue).toBe(1);
+
+            // Use Custom Procedure with the same name "get_record"
+            const customRecords = await primitiveStream.customGetProcedure(
+                "get_record",
+                {
+                  dateFrom: 1,
+                  dateTo: 1,
+                },
+            );
+
+            // Verify record content from the custom procedure
+            expect(customRecords.length).toBe(1);
+            expect(customRecords[0].value).toBe("1.000000000000000000");
+            expect(customRecords[0].dateValue).toBe(1);
+
+            // Query index
+            const index = await primitiveStream.getIndex({
+              dateFrom: 1,
+              dateTo: 1,
+            });
+
+            // Verify index content
+            expect(index.length).toBe(1);
+            expect(index[0].value).toBe("100.000000000000000000");
+            expect(index[0].dateValue).toBe(1);
+
+            // Query first record
+            const firstRecord = await primitiveStream.getFirstRecord({});
+            expect(firstRecord).not.toBeNull();
+            expect(firstRecord?.value).toBe("1.000000000000000000");
+            expect(firstRecord?.dateValue).toBe(1);
+          } finally {
+            // Cleanup: destroy the stream after test
+            await defaultClient.destroyStream(streamId, true);
+          }
+        }, 60000,
     );
   },
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

This pull request introduces changes to support multiple contract versions and updates various interfaces to handle both string and number date values. Additionally, it includes new integration tests to verify the functionality of the new contract versions.

### Support for Multiple Contract Versions:
* [`src/client/client.ts`](diffhunk://#diff-ed2b939cef6b7455068ab86c443272afeb42f47a0264b82ec98fbd19d774e4d1R108-R123): Added `contractVersion` parameter to the `deployStream` method to support different contract versions.
* [`src/contracts-api/deployStream.ts`](diffhunk://#diff-29a4095573e83dcffd330e90d92ddbf0525792551a5eb919657295cb405a9aa5R8-R9): Updated `DeployStreamInput` and `deployStream` function to include `contractVersion`. Modified `getContract` function to return the appropriate contract template based on the `contractVersion`. [[1]](diffhunk://#diff-29a4095573e83dcffd330e90d92ddbf0525792551a5eb919657295cb405a9aa5R8-R9) [[2]](diffhunk://#diff-29a4095573e83dcffd330e90d92ddbf0525792551a5eb919657295cb405a9aa5R21) [[3]](diffhunk://#diff-29a4095573e83dcffd330e90d92ddbf0525792551a5eb919657295cb405a9aa5L34-R37) [[4]](diffhunk://#diff-29a4095573e83dcffd330e90d92ddbf0525792551a5eb919657295cb405a9aa5R59-R67)
* [`src/contracts/contractsContent.ts`](diffhunk://#diff-569b00fb47ed44a826e2af150b01fbe9d2fad4e662405afa2b51c9c13c0e84acR3-R6): Imported and exported new contract templates for Unix-based streams. Added tests to verify the new contract templates. [[1]](diffhunk://#diff-569b00fb47ed44a826e2af150b01fbe9d2fad4e662405afa2b51c9c13c0e84acR3-R6) [[2]](diffhunk://#diff-569b00fb47ed44a826e2af150b01fbe9d2fad4e662405afa2b51c9c13c0e84acR20-R29)

### Date Handling Improvements:
* [`src/contracts-api/composedStream.ts`](diffhunk://#diff-f3da9c83b146e72583462acbc9e485a7908acd2b0a01c0ed9a6257b8dd7b5340L16-R16): Updated interfaces and methods to handle both string and number date values. [[1]](diffhunk://#diff-f3da9c83b146e72583462acbc9e485a7908acd2b0a01c0ed9a6257b8dd7b5340L16-R16) [[2]](diffhunk://#diff-f3da9c83b146e72583462acbc9e485a7908acd2b0a01c0ed9a6257b8dd7b5340L85-R85) [[3]](diffhunk://#diff-f3da9c83b146e72583462acbc9e485a7908acd2b0a01c0ed9a6257b8dd7b5340L96-R96) [[4]](diffhunk://#diff-f3da9c83b146e72583462acbc9e485a7908acd2b0a01c0ed9a6257b8dd7b5340L106-R112)
* [`src/contracts-api/primitiveStream.ts`](diffhunk://#diff-9b17cd29bf417aceb29074598b772f863ec4fb1c9bb14b123a5f77941267ad45L87-R87): Updated `InsertRecordInput` interface to accept both string and number date values.
* [`src/contracts-api/stream.ts`](diffhunk://#diff-0563d7d43f9ec82d3d4d38600ce078d0444ed1e272efd5ec79769f5fb7559cc8L23-R35): Updated various interfaces to handle both string and number date values.

### Integration Tests:
* [`tests/integration/composedStream.test.ts`](diffhunk://#diff-9dc477b8de599b0cb586ef4a83d81dd85e6acb56e672bbdfca0b523a59e796efR29-R33): Added a new test to verify the deployment, initialization, and usage of a composed stream with contract version 2. [[1]](diffhunk://#diff-9dc477b8de599b0cb586ef4a83d81dd85e6acb56e672bbdfca0b523a59e796efR29-R33) [[2]](diffhunk://#diff-9dc477b8de599b0cb586ef4a83d81dd85e6acb56e672bbdfca0b523a59e796efR148-R296)
* [`tests/integration/primitiveStream.test.ts`](diffhunk://#diff-6eec7a335f4ee2ff4f9c68c3af90143188e86af609c7cb13cbd6944ee838fd90L94-R94): Added a new test to verify the deployment, initialization, writing to, and reading from a primitive stream with contract version 2. [[1]](diffhunk://#diff-6eec7a335f4ee2ff4f9c68c3af90143188e86af609c7cb13cbd6944ee838fd90L94-R94) [[2]](diffhunk://#diff-6eec7a335f4ee2ff4f9c68c3af90143188e86af609c7cb13cbd6944ee838fd90R158-R248)

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/sdk-js/issues/30

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Run test locally