### PR TITLE
fix: unable to publish npm packages via CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
         required: false
         default: ""
 
+permissions: write-all
+
 jobs:
   create_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

It looks like the `GITHUB_TOKEN` permission is defaulted to `none` now, So I set the permission in the CI file.

This pull request includes a small change to the `.github/workflows/release.yml` file. The change adds a new permission setting to the workflow.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R11-R12): Added `permissions: write-all` to the workflow configuration.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/sdk-js/issues/32

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested here: https://github.com/MicBun/sdk-js/releases/tag/v0.2.4