### PR TITLE
feat: read operations on the new architecture

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "publish:dev": "pnpm publish --tag dev --no-git-checks"
   },
   "dependencies": {
-    "@kwilteam/kwil-js": "^0.9.3",
+    "@kwilteam/kwil-js": "^0.9.4",
     "crypto-hash": "^3.1.0",
     "ethers": "^6.13.5",
     "lodash": "^4.17.21",

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -50,7 +50,14 @@ export abstract class BaseTNClient<T extends EnvironmentType> {
           .catch(() => ({ data: undefined, status: undefined }));
         switch (receipt.status) {
           case 200:
-            resolve(receipt.data!);
+            if (receipt.data?.tx_result?.log !== undefined && receipt.data?.tx_result?.log.includes("ERROR")) {
+              reject(
+                  new Error(
+                      `Transaction failed: status ${receipt.status} : log message ${receipt.data?.tx_result.log}`,
+                  ))
+            } else {
+              resolve(receipt.data!);
+            }
             break;
           case undefined:
             break;

--- a/src/contracts-api/composedStream.ts
+++ b/src/contracts-api/composedStream.ts
@@ -64,7 +64,7 @@ export class ComposedStream extends Stream {
     inputs: ActionInput[],
   ): Promise<GenericResponse<TxReceipt>> {
     await this.checkValidComposedStream();
-    return this.execute(method, inputs);
+    return this.executeWithNamedParams(method, inputs);
   }
 
   /**

--- a/tests/integration/composedStream.test.ts
+++ b/tests/integration/composedStream.test.ts
@@ -108,8 +108,8 @@ describe.sequential(
 
           // Query records after the taxonomy start date
           const records = await composedStream.getRecord({
-            dateFrom: "2020-02-01",
-            dateTo: "2020-02-02",
+            from: "2020-02-01",
+            to: "2020-02-02",
           });
 
           // Verify records
@@ -122,9 +122,9 @@ describe.sequential(
 
           // Query index values
           const index = await composedStream.getIndex({
-            dateFrom: "2020-01-30",
-            dateTo: "2020-02-01",
-            baseDate: "2020-01-30",
+            from: "2020-01-30",
+            to: "2020-02-01",
+            baseTime: "2020-01-30",
           });
 
           // Verify index values
@@ -245,8 +245,8 @@ describe.sequential(
 
             // Query records after the taxonomy start date
             const records = await composedStream.getRecord({
-              dateFrom: 4,
-              dateTo: 5,
+              from: 4,
+              to: 5,
             });
 
             // Verify records
@@ -259,9 +259,9 @@ describe.sequential(
 
             // Query index values
             const index = await composedStream.getIndex({
-              dateFrom: 3,
-              dateTo: 4,
-              baseDate: 3,
+              from: 3,
+              to: 4,
+              baseTime: 3,
             });
 
             // Verify index values

--- a/tests/integration/composedStream.test.ts
+++ b/tests/integration/composedStream.test.ts
@@ -108,8 +108,8 @@ describe.sequential(
 
           // Query records after the taxonomy start date
           const records = await composedStream.getRecord({
-            from: "2020-02-01",
-            to: "2020-02-02",
+            from: new Date("2020-02-01").getTime() / 1000,
+            to: new Date("2020-02-02").getTime() / 1000,
           });
 
           // Verify records

--- a/tests/integration/permissions.test.ts
+++ b/tests/integration/permissions.test.ts
@@ -50,8 +50,8 @@ describe.sequential("Permissions", { timeout: 90000 }, () => {
 
         // Test public read access
         const publicRecords = await readerPrimitiveStream.getRecord({
-          dateFrom: "2024-01-01",
-          dateTo: "2024-01-01",
+          from: "2024-01-01",
+          to: "2024-01-01",
         });
         expect(publicRecords.length).toBe(1);
         expect(publicRecords[0].value).toBe("100.000000000000000000");
@@ -62,16 +62,16 @@ describe.sequential("Permissions", { timeout: 90000 }, () => {
 
         // Verify owner can still read
         const ownerRecords = await primitiveStream.getRecord({
-          dateFrom: "2024-01-01",
-          dateTo: "2024-01-01",
+          from: "2024-01-01",
+          to: "2024-01-01",
         });
         expect(ownerRecords.length).toBe(1);
 
         // Verify reader cannot read when private
         await expect(
           readerPrimitiveStream.getRecord({
-            dateFrom: "2024-01-01",
-            dateTo: "2024-01-01",
+            from: "2024-01-01",
+            to: "2024-01-01",
           }),
         ).rejects.toThrow();
 
@@ -82,8 +82,8 @@ describe.sequential("Permissions", { timeout: 90000 }, () => {
 
         // Verify reader can now read
         const allowedRecords = await readerPrimitiveStream.getRecord({
-          dateFrom: "2024-01-01",
-          dateTo: "2024-01-01",
+          from: "2024-01-01",
+          to: "2024-01-01",
         });
         expect(allowedRecords.length).toBe(1);
 
@@ -94,8 +94,8 @@ describe.sequential("Permissions", { timeout: 90000 }, () => {
         // Verify reader cannot read after being disabled
         await expect(
           readerPrimitiveStream.getRecord({
-            dateFrom: "2024-01-01",
-            dateTo: "2024-01-01",
+            from: "2024-01-01",
+            to: "2024-01-01",
           }),
         ).rejects.toThrow();
       } finally {
@@ -158,8 +158,8 @@ describe.sequential("Permissions", { timeout: 90000 }, () => {
 
         // Test public access
         const publicRecords = await readerComposedStream.getRecord({
-          dateFrom: "2024-01-01",
-          dateTo: "2024-01-01",
+          from: "2024-01-01",
+          to: "2024-01-01",
         });
         expect(publicRecords.length).toBe(1);
 
@@ -170,8 +170,8 @@ describe.sequential("Permissions", { timeout: 90000 }, () => {
         // Verify composed stream fails when child is private
         await expect(
           readerComposedStream.getRecord({
-            dateFrom: "2024-01-01",
-            dateTo: "2024-01-01",
+            from: "2024-01-01",
+            to: "2024-01-01",
           }),
         ).rejects.toThrow();
 
@@ -183,8 +183,8 @@ describe.sequential("Permissions", { timeout: 90000 }, () => {
 
         // Verify composed stream works when allowed
         const allowedRecords = await readerComposedStream.getRecord({
-          dateFrom: "2024-01-01",
-          dateTo: "2024-01-01",
+          from: "2024-01-01",
+          to: "2024-01-01",
         });
         expect(allowedRecords.length).toBe(1);
 
@@ -195,8 +195,8 @@ describe.sequential("Permissions", { timeout: 90000 }, () => {
         // Verify reader cannot access private composed stream
         await expect(
           readerComposedStream.getRecord({
-            dateFrom: "2024-01-01",
-            dateTo: "2024-01-01",
+            from: "2024-01-01",
+            to: "2024-01-01",
           }),
         ).rejects.toThrow();
 
@@ -207,8 +207,8 @@ describe.sequential("Permissions", { timeout: 90000 }, () => {
 
         // Verify reader can access when allowed
         const finalRecords = await readerComposedStream.getRecord({
-          dateFrom: "2024-01-01",
-          dateTo: "2024-01-01",
+          from: "2024-01-01",
+          to: "2024-01-01",
         });
         expect(finalRecords.length).toBe(1);
       } finally {

--- a/tests/integration/permissions.test.ts
+++ b/tests/integration/permissions.test.ts
@@ -50,8 +50,8 @@ describe.sequential("Permissions", { timeout: 90000 }, () => {
 
         // Test public read access
         const publicRecords = await readerPrimitiveStream.getRecord({
-          from: "2024-01-01",
-          to: "2024-01-01",
+          from: new Date("2024-01-01").getTime() / 1000,
+          to: new Date("2024-01-01").getTime() / 1000,
         });
         expect(publicRecords.length).toBe(1);
         expect(publicRecords[0].value).toBe("100.000000000000000000");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

This pull request includes several changes to improve the functionality and consistency of the `Stream` classes and their associated methods. The most important changes include updating dependencies, modifying method signatures, and refactoring the code to use more descriptive parameter names.

### Dependency Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L51-R51): Updated the `@kwilteam/kwil-js` dependency from version `^0.9.3` to `^0.9.4`.

### Code Refactoring:
* [`src/client/client.ts`](diffhunk://#diff-ed2b939cef6b7455068ab86c443272afeb42f47a0264b82ec98fbd19d774e4d1R53-R60): Added a check to handle transaction errors by rejecting the promise with a detailed error message if the log contains "ERROR".
* [`src/contracts-api/composedStream.ts`](diffhunk://#diff-f3da9c83b146e72583462acbc9e485a7908acd2b0a01c0ed9a6257b8dd7b5340L67-R67): Changed the method call from `execute` to `executeWithNamedParams` for better clarity and consistency.
* [`src/contracts-api/primitiveStream.ts`](diffhunk://#diff-9b17cd29bf417aceb29074598b772f863ec4fb1c9bb14b123a5f77941267ad45L41-R56): Modified the `insertRecord` and `insertRecords` methods to use `executeWithActionBody` with named parameters and data types. [[1]](diffhunk://#diff-9b17cd29bf417aceb29074598b772f863ec4fb1c9bb14b123a5f77941267ad45L41-R56) [[2]](diffhunk://#diff-9b17cd29bf417aceb29074598b772f863ec4fb1c9bb14b123a5f77941267ad45L57-R82)
* [`src/contracts-api/stream.ts`](diffhunk://#diff-0563d7d43f9ec82d3d4d38600ce078d0444ed1e272efd5ec79769f5fb7559cc8L1-L3): Refactored multiple methods to use more descriptive parameter names (e.g., `from`, `to`, `eventTime`) and updated method signatures to use `executeWithNamedParams` and `executeWithActionBody`. [[1]](diffhunk://#diff-0563d7d43f9ec82d3d4d38600ce078d0444ed1e272efd5ec79769f5fb7559cc8L1-L3) [[2]](diffhunk://#diff-0563d7d43f9ec82d3d4d38600ce078d0444ed1e272efd5ec79769f5fb7559cc8R20-R43) [[3]](diffhunk://#diff-0563d7d43f9ec82d3d4d38600ce078d0444ed1e272efd5ec79769f5fb7559cc8L57-R60) [[4]](diffhunk://#diff-0563d7d43f9ec82d3d4d38600ce078d0444ed1e272efd5ec79769f5fb7559cc8R74-R94) [[5]](diffhunk://#diff-0563d7d43f9ec82d3d4d38600ce078d0444ed1e272efd5ec79769f5fb7559cc8L98-R123) [[6]](diffhunk://#diff-0563d7d43f9ec82d3d4d38600ce078d0444ed1e272efd5ec79769f5fb7559cc8L124-R148) [[7]](diffhunk://#diff-0563d7d43f9ec82d3d4d38600ce078d0444ed1e272efd5ec79769f5fb7559cc8L176-R201) [[8]](diffhunk://#diff-0563d7d43f9ec82d3d4d38600ce078d0444ed1e272efd5ec79769f5fb7559cc8L203-R213) [[9]](diffhunk://#diff-0563d7d43f9ec82d3d4d38600ce078d0444ed1e272efd5ec79769f5fb7559cc8L375-R385) [[10]](diffhunk://#diff-0563d7d43f9ec82d3d4d38600ce078d0444ed1e272efd5ec79769f5fb7559cc8L416-R442) [[11]](diffhunk://#diff-0563d7d43f9ec82d3d4d38600ce078d0444ed1e272efd5ec79769f5fb7559cc8L449-R472) [[12]](diffhunk://#diff-0563d7d43f9ec82d3d4d38600ce078d0444ed1e272efd5ec79769f5fb7559cc8L482-R500)

### Test Updates:
* `tests/integration/composedStream.test.ts` and `tests/integration/permissions.test.ts`: Updated test cases to reflect the new parameter names (`from`, `to`, `baseTime`) in method calls. [[1]](diffhunk://#diff-9dc477b8de599b0cb586ef4a83d81dd85e6acb56e672bbdfca0b523a59e796efL111-R112) [[2]](diffhunk://#diff-9dc477b8de599b0cb586ef4a83d81dd85e6acb56e672bbdfca0b523a59e796efL125-R127) [[3]](diffhunk://#diff-9dc477b8de599b0cb586ef4a83d81dd85e6acb56e672bbdfca0b523a59e796efL248-R249) [[4]](diffhunk://#diff-9dc477b8de599b0cb586ef4a83d81dd85e6acb56e672bbdfca0b523a59e796efL262-R264) [[5]](diffhunk://#diff-c43dfb9ba400cfa482f17afcf6cfb45f50c7ae2587b9228400cf58085d0ef2c4L53-R54) [[6]](diffhunk://#diff-c43dfb9ba400cfa482f17afcf6cfb45f50c7ae2587b9228400cf58085d0ef2c4L65-R74) [[7]](diffhunk://#diff-c43dfb9ba400cfa482f17afcf6cfb45f50c7ae2587b9228400cf58085d0ef2c4L85-R86) [[8]](diffhunk://#diff-c43dfb9ba400cfa482f17afcf6cfb45f50c7ae2587b9228400cf58085d0ef2c4L97-R98) [[9]](diffhunk://#diff-c43dfb9ba400cfa482f17afcf6cfb45f50c7ae2587b9228400cf58085d0ef2c4L161-R162)

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/sdk-js/issues/50

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

test all primitiveStream.test.ts