### PR TITLE
feat: view latest write transactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ out
 # env
 .env.*
 !.env.example
+*.env

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -68,6 +68,13 @@ async function safeDestroy(client: NodeTNClient, streamId: StreamId) {
         },
     });
 
+    // Example of using the client to get the last transactions.
+    const lastTransactions = await client.getLastTransactions({
+        dataProvider: undefined,
+        limitSize: 6,
+    });
+    console.log("Last transactions:", lastTransactions);
+
     // Create a new stream ID.
     const streamIdNew = await StreamId.generate("new-stream-id");
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -16,6 +16,7 @@ import { StreamLocator } from "../types/stream";
 import { EthereumAddress } from "../util/EthereumAddress";
 import { StreamId } from "../util/StreamId";
 import { listStreams } from "./listStreams";
+import { getLastTransactions } from "./getLastTransactions";
 
 export interface SignerInfo {
   // we need to have the address upfront to create the KwilSigner, instead of relying on the signer to return it asynchronously
@@ -33,6 +34,15 @@ export interface ListStreamsInput {
     limit?: number;
     offset?: number;
     orderBy?: string;
+}
+
+/**
+ * @param dataProvider optional address; when omitted or null, returns for all providers
+ * @param limitSize max rows to return (default 6, max 100)
+ */
+export interface GetLastTransactionsInput {
+  dataProvider?: string;
+  limitSize?: number;
 }
 
 export abstract class BaseTNClient<T extends EnvironmentType> {
@@ -201,6 +211,17 @@ export abstract class BaseTNClient<T extends EnvironmentType> {
   async getListStreams(input: ListStreamsInput): Promise<StreamLocator[]> {
     return listStreams(this.getKwilClient() as WebKwil | NodeKwil,this.getKwilSigner(),input);
   }
+
+  //getLastTransactions
+
+    /**
+     * Returns the last write activity across streams.
+     * @param input - The input parameters for getting last transactions.
+     * @returns A promise that resolves to a list of last transactions.
+     */
+    async getLastTransactions(input: GetLastTransactionsInput): Promise<any[]> {
+        return getLastTransactions(this.getKwilClient() as WebKwil | NodeKwil,this.getKwilSigner(),input);
+    }
 
   /**
    * Get the default chain id for a provider. Use with caution, as this decreases the security of the TN.

--- a/src/client/getLastTransactions.ts
+++ b/src/client/getLastTransactions.ts
@@ -1,0 +1,58 @@
+import { WebKwil, NodeKwil, KwilSigner } from "@kwilteam/kwil-js";
+import { GetLastTransactionsInput } from "./client";
+import { LastTransaction } from "../types/transaction";
+
+const INDEXER_BASE = "https://indexer.infra.truf.network";
+
+export async function getLastTransactions(
+    kwilClient: WebKwil | NodeKwil,
+    kwilSigner: KwilSigner,
+    input: GetLastTransactionsInput
+): Promise<LastTransaction[]> {
+    // 1) call your SQL action
+    const res = await kwilClient.call(
+        {
+            name: "get_last_transactions",
+            namespace: "main",
+            inputs: {
+                $data_provider: input.dataProvider ?? null,
+                $limit_size: input.limitSize ?? 6,
+            },
+        },
+        kwilSigner
+    );
+
+    const rows =
+        (res.data?.result as { created_at: number; method: string }[]) || [];
+
+    // 2) for each row, hit the indexer to grab sender & tx hash
+    return Promise.all(
+        rows.map(async (r) => {
+            const url = `${INDEXER_BASE}/v0/chain/transactions`
+                + `?from-block=${r.created_at}`
+                + `&to-block=${r.created_at}`
+                + `&order=asc&limit=1`;
+
+            const resp = await fetch(url);
+            if (!resp.ok) {
+                throw new Error(`Indexer fetch failed: ${resp.status}`);
+            }
+            const json = await resp.json() as {
+                ok: boolean;
+                data: Array<{
+                    hash: string;
+                    sender: string;
+                    /* ... */
+                }>;
+            };
+
+            const tx = json.data[0];
+            return {
+                blockHeight: r.created_at,
+                method: r.method,
+                sender: tx.sender,
+                transactionHash: tx.hash,
+            };
+        })
+    );
+}

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -1,0 +1,10 @@
+export interface LastTransaction {
+    /** Block height */
+    blockHeight: number;
+    /** Which action was taken */
+    method: string;
+    /** Address that sent the on‐chain tx */
+    sender: string;
+    /** Hash of the on‐chain transaction */
+    transactionHash: string;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

We can now get
transactionId
sender
blockHeight
method

any idea to get created_at in timestamp?

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/sdk-js/issues/67

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

![image](https://github.com/user-attachments/assets/f71ffa0e-e6f3-431a-8175-5501b0dbb619)