### PR TITLE
chore: import pg only on node client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Used in testing. Points to hosts' node repository, required to run migration files
+# If you use this, don't forget that changes there have effect on these tests.
+NODE_REPO_DIR=path/to/trufnetwork/node/repo

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ out
 *.tsbuildinfo.json
 
 # env
+.env
 .env.*
 !.env.example
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ out
 
 .idea
 package-lock.json
+
+/gitignore

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "vite-plugin-plain-text": "1.4.2",
     "vitest": "3.2.0-beta.2",
     "@vitest/browser": "3.2.0-beta.2",
-    "playwright": "1.52.0"
+    "playwright": "1.52.0",
+    "dotenv": "^16.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,11 +48,12 @@
     "publish:dev": "pnpm publish --tag dev --no-git-checks"
   },
   "dependencies": {
-    "@kwilteam/kwil-js": "^0.7.3",
+    "@kwilteam/kwil-js": "~0.8.0",
     "crypto-hash": "^3.1.0",
     "lodash": "^4.17.21",
     "monads-io": "^4.0.2",
-    "pg": "^8.14.1"
+    "pg": "^8.14.1",
+    "ethers": "^6.0.0"
   },
   "devDependencies": {
     "@types/lodash": "4.17.12",
@@ -78,6 +79,8 @@
     "tsx": "^4.19.1",
     "typescript": "^5.6.3",
     "vite-plugin-plain-text": "1.4.2",
-    "vitest": "^2.1.3"
+    "vitest": "3.2.0-beta.2",
+    "@vitest/browser": "3.2.0-beta.2",
+    "playwright": "1.52.0"
   }
 }

--- a/src/client/browserClient.ts
+++ b/src/client/browserClient.ts
@@ -1,9 +1,14 @@
 import { EnvironmentType } from "@kwilteam/kwil-js/dist/core/enums";
 import { WebKwil } from "@kwilteam/kwil-js";
 import { BaseTNClient, TNClientOptions } from "./client";
+import { isBrowser } from "../util/isBrowser";
 
 export class BrowserTNClient extends BaseTNClient<EnvironmentType.BROWSER> {
   constructor(options: TNClientOptions) {
+    if (isBrowser && options.neonConnectionString) {
+      console.warn("Neon connection string is not supported in browser environments. Database operations won't be performed.");
+    }
+
     super(options);
     this.kwilClient = new WebKwil({
       ...options,

--- a/src/client/browserClient.ts
+++ b/src/client/browserClient.ts
@@ -1,11 +1,11 @@
 import { EnvironmentType } from "@kwilteam/kwil-js/dist/core/enums";
 import { WebKwil } from "@kwilteam/kwil-js";
 import { BaseTNClient, TNClientOptions } from "./client";
-import { isBrowser } from "../util/isBrowser";
+import { type Pool } from "pg";
 
 export class BrowserTNClient extends BaseTNClient<EnvironmentType.BROWSER> {
   constructor(options: TNClientOptions) {
-    if (isBrowser && options.neonConnectionString) {
+    if (options.neonConnectionString) {
       console.warn("Neon connection string is not supported in browser environments. Database operations won't be performed.");
     }
 
@@ -14,6 +14,10 @@ export class BrowserTNClient extends BaseTNClient<EnvironmentType.BROWSER> {
       ...options,
       kwilProvider: options.endpoint,
     });
+  }
+
+  protected getPool(): Pool | undefined {
+    return undefined;
   }
 }
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -16,6 +16,7 @@ import { StreamLocator } from "../types/stream";
 import { EthereumAddress } from "../util/EthereumAddress";
 import { StreamId } from "../util/StreamId";
 import { listAllStreams } from "./listAllStreams";
+import { type Pool } from "pg";
 
 export interface SignerInfo {
   // we need to have the address upfront to create the KwilSigner, instead of relying on the signer to return it asynchronously
@@ -131,7 +132,7 @@ export abstract class BaseTNClient<T extends EnvironmentType> {
       kwilClient: this.getKwilClient(),
       kwilSigner: this.getKwilSigner(),
       contractVersion: contractVersion,
-      neonConnectionString: this.getNeonConnectionString(),
+      pool: this.getPool(),
     });
   }
 
@@ -185,7 +186,7 @@ export abstract class BaseTNClient<T extends EnvironmentType> {
       this.getKwilClient() as WebKwil | NodeKwil,
       this.getKwilSigner(),
       stream,
-      this.getNeonConnectionString(),
+      this.getPool(),
     );
   }
 
@@ -230,4 +231,7 @@ export abstract class BaseTNClient<T extends EnvironmentType> {
     const chainInfo = await kwilClient["chainInfoClient"]();
     return chainInfo.data?.chain_id;
   }
+
+
+  protected abstract getPool(): Pool | undefined;
 }

--- a/src/client/nodeClient.ts
+++ b/src/client/nodeClient.ts
@@ -1,7 +1,7 @@
 import { EnvironmentType } from "@kwilteam/kwil-js/dist/core/enums";
 import { NodeKwil } from "@kwilteam/kwil-js";
 import { BaseTNClient, TNClientOptions } from "./client";
-
+import { Pool } from "pg";
 export class NodeTNClient extends BaseTNClient<EnvironmentType.NODE> {
   constructor(options: TNClientOptions) {
     super(options);
@@ -9,6 +9,13 @@ export class NodeTNClient extends BaseTNClient<EnvironmentType.NODE> {
       ...options,
       kwilProvider: options.endpoint,
     });
+  }
+
+  protected getPool(): Pool | undefined {
+    if (this.neonConnectionString) {
+      return new Pool({ connectionString: this.neonConnectionString });
+    }
+    return undefined;
   }
 }
 

--- a/src/client/nodeClient.ts
+++ b/src/client/nodeClient.ts
@@ -1,7 +1,7 @@
 import { EnvironmentType } from "@kwilteam/kwil-js/dist/core/enums";
 import { NodeKwil } from "@kwilteam/kwil-js";
 import { BaseTNClient, TNClientOptions } from "./client";
-import { Pool } from "pg";
+import { type Pool } from "pg";
 export class NodeTNClient extends BaseTNClient<EnvironmentType.NODE> {
   constructor(options: TNClientOptions) {
     super(options);
@@ -12,6 +12,8 @@ export class NodeTNClient extends BaseTNClient<EnvironmentType.NODE> {
   }
 
   protected getPool(): Pool | undefined {
+    const pg = require("pg");
+    const { Pool } = pg;
     if (this.neonConnectionString) {
       return new Pool({ connectionString: this.neonConnectionString });
     }

--- a/src/util/isBrowser.ts
+++ b/src/util/isBrowser.ts
@@ -1,1 +1,0 @@
-export const isBrowser = typeof window !== "undefined";

--- a/src/util/isBrowser.ts
+++ b/src/util/isBrowser.ts
@@ -1,0 +1,1 @@
+export const isBrowser = typeof window !== "undefined";

--- a/tests/no-pg.browser.spec.ts
+++ b/tests/no-pg.browser.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+
+// This test ensures that importing the browser-specific client does not statically import or require 'pg'.
+// If 'pg' were statically imported in browser code, this import would fail in a bundler/browser environment.
+import { BrowserTNClient } from "../src/index.browser";
+
+describe('Browser entrypoint', () => {
+  it('should only export browser-safe APIs', () => {
+    // core smoke test
+    expect(typeof BrowserTNClient).toBe('function');
+    // ensure we're running in a browser environment
+    //
+    expect(typeof window).not.toBe('undefined');
+  });
+}); 
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,7 +31,6 @@ export default defineConfig({
       {
         test: { // Inner test config for browser project
           name: 'browser',
-          setupFiles: ['dotenv/config'],
           maxConcurrency: 1,
           browser: {
             enabled: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,11 +2,48 @@
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
-
   test: {
-    includeSource: ['src/**/*.{js,ts}'], 
+    includeSource: [''],
     setupFiles: ['disposablestack/auto'],
     maxConcurrency: 1, // Disable concurrency to avoid nonce errors
     fileParallelism: false,
+    projects: [
+      {
+        test: { // Inner test config for node project
+          name: 'node',
+          environment: 'node',
+          include: [
+            'src/**/*.test.ts',
+            'src/**/*.spec.ts',
+            'tests/**/*.test.ts',
+            'tests/**/*.spec.ts',
+          ],
+          exclude: [
+            'src/**/*.browser.test.ts',
+            'src/**/*.browser.spec.ts',
+            'tests/**/*.browser.test.ts',
+            'tests/**/*.browser.spec.ts',
+          ],
+        }
+      },
+      {
+        test: { // Inner test config for browser project
+          name: 'browser',
+          browser: {
+            enabled: true,
+            provider: 'playwright',
+            instances: [
+              { browser: 'chromium', headless: true },
+            ],
+          },
+          include: [
+            'src/**/*.browser.test.ts',
+            'src/**/*.browser.spec.ts',
+            'tests/**/*.browser.test.ts',
+            'tests/**/*.browser.spec.ts',
+          ],
+        }
+      },
+    ],
   },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,13 +4,15 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     includeSource: [''],
-    setupFiles: ['disposablestack/auto'],
+    setupFiles: ['disposablestack/auto', 'dotenv/config'],
     maxConcurrency: 1, // Disable concurrency to avoid nonce errors
     fileParallelism: false,
     projects: [
       {
         test: { // Inner test config for node project
           name: 'node',
+          setupFiles: ['disposablestack/auto', 'dotenv/config'],
+          maxConcurrency: 1,
           environment: 'node',
           include: [
             'src/**/*.test.ts',
@@ -29,6 +31,8 @@ export default defineConfig({
       {
         test: { // Inner test config for browser project
           name: 'browser',
+          setupFiles: ['dotenv/config'],
+          maxConcurrency: 1,
           browser: {
             enabled: true,
             provider: 'playwright',

--- a/vitest.shims.d.ts
+++ b/vitest.shims.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@vitest/browser/providers/playwright" /> 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- `pg` is a library that should only be used in Node environments
- Through deps injection, we're able to import and instantiate only on the node client
- It's not intended to be used in the browser anyway, as this could expose credentials at the client

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

- fix #76 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The tests passed, and I could create a nextjs page without compile erorrs
