### PR TITLE
feat: add role-management helpers

### DIFF
--- a/src/contracts-api/roleManagement.ts
+++ b/src/contracts-api/roleManagement.ts
@@ -1,0 +1,146 @@
+import { KwilSigner, NodeKwil, Utils, WebKwil } from "@kwilteam/kwil-js";
+import { GenericResponse } from "@kwilteam/kwil-js/dist/core/resreq";
+import { TxReceipt } from "@kwilteam/kwil-js/dist/core/tx";
+import { Action } from "./action";
+import { AreMembersOfInput, GrantRoleInput, RevokeRoleInput, WalletMembership } from "../types/role";
+import DataType = Utils.DataType;
+import { OwnerIdentifier } from "../types/role";
+import { EthereumAddress } from "../util/EthereumAddress";
+
+/**
+ * RoleManagement provides convenient wrappers around the on-chain SQL actions
+ * that implement the RBAC system (grant_roles, revoke_roles, are_members_of).
+ */
+export class RoleManagement extends Action {
+  constructor(kwilClient: WebKwil | NodeKwil, kwilSigner: KwilSigner) {
+    super(kwilClient, kwilSigner);
+  }
+
+  private static normalizeOwner(owner: OwnerIdentifier): string {
+    return owner === "system"
+      ? "system"
+      : owner.getAddress().toLowerCase();
+  }
+
+  private static normalizeWallets(wallets: EthereumAddress[]): string[] {
+    return wallets.map((w) => w.getAddress().toLowerCase());
+  }
+
+  /**
+   * Grants a role to the provided wallets.
+   * This calls the `grant_roles` action.
+   */
+  public async grantRole(
+    input: GrantRoleInput,
+    synchronous = false,
+  ): Promise<GenericResponse<TxReceipt>> {
+    return this.executeWithActionBody(
+      {
+        namespace: "main",
+        name: "grant_roles",
+        inputs: [
+          {
+            $owner: RoleManagement.normalizeOwner(input.owner),
+            $role_name: input.roleName.toLowerCase(),
+            $wallets: RoleManagement.normalizeWallets(input.wallets),
+          },
+        ],
+        types: {
+          $owner: DataType.Text,
+          $role_name: DataType.Text,
+          $wallets: DataType.TextArray,
+        },
+      },
+      synchronous,
+    );
+  }
+
+  /**
+   * Revokes a role from the provided wallets.
+   * This calls the `revoke_roles` action.
+   */
+  public async revokeRole(
+    input: RevokeRoleInput,
+    synchronous = false,
+  ): Promise<GenericResponse<TxReceipt>> {
+    return this.executeWithActionBody(
+      {
+        namespace: "main",
+        name: "revoke_roles",
+        inputs: [
+          {
+            $owner: RoleManagement.normalizeOwner(input.owner),
+            $role_name: input.roleName.toLowerCase(),
+            $wallets: RoleManagement.normalizeWallets(input.wallets),
+          },
+        ],
+        types: {
+          $owner: DataType.Text,
+          $role_name: DataType.Text,
+          $wallets: DataType.TextArray,
+        },
+      },
+      synchronous,
+    );
+  }
+
+  /**
+   * Checks if the provided wallets are members of a role.
+   * This calls the `are_members_of` VIEW action.
+   *
+   * @returns an array matching the provided wallets order with membership flags.
+   */
+  public async areMembersOf(
+    input: AreMembersOfInput,
+  ): Promise<WalletMembership[]> {
+    const result = await this.call<{ wallet: string; is_member: boolean }[]>(
+      "are_members_of",
+      {
+        $owner: RoleManagement.normalizeOwner(input.owner),
+        $role_name: input.roleName.toLowerCase(),
+        $wallets: RoleManagement.normalizeWallets(input.wallets),
+      },
+    );
+
+    // Either.throw() will return the right value or throw with the left value (status code)
+    return result.throw().map((row) => ({
+      wallet: row.wallet,
+      isMember: row.is_member,
+    }));
+  }
+
+  /**
+   * Lists the members of a role with optional pagination.
+   * This calls the `list_role_members` VIEW action.
+   */
+  public async listRoleMembers(
+    input: import("../types/role").ListRoleMembersInput,
+  ): Promise<import("../types/role").RoleMember[]> {
+    const result = await this.call<{
+      wallet: string;
+      granted_at: number;
+      granted_by: string;
+    }[]>("list_role_members", {
+      $owner: RoleManagement.normalizeOwner(input.owner),
+      $role_name: input.roleName.toLowerCase(),
+      ...(input.limit !== undefined ? { $limit: input.limit } : {}),
+      ...(input.offset !== undefined ? { $offset: input.offset } : {}),
+    });
+
+    return result.throw().map((row) => ({
+      wallet: row.wallet,
+      grantedAt: Number(row.granted_at),
+      grantedBy: row.granted_by,
+    }));
+  }
+
+  /**
+   * Helper factory mirroring the pattern used by the other action wrappers.
+   */
+  public static fromClient(
+    kwilClient: WebKwil | NodeKwil,
+    kwilSigner: KwilSigner,
+  ): RoleManagement {
+    return new RoleManagement(kwilClient, kwilSigner);
+  }
+} 

--- a/src/index.common.ts
+++ b/src/index.common.ts
@@ -23,3 +23,7 @@ export { Action } from "./contracts-api/action";
 export { PrimitiveAction } from "./contracts-api/primitiveAction";
 export { ComposedAction } from "./contracts-api/composedAction";
 
+// Role management exports
+export { RoleManagement } from "./contracts-api/roleManagement";
+export type { GrantRoleInput, RevokeRoleInput, AreMembersOfInput, WalletMembership } from "./types/role";
+

--- a/src/types/role.ts
+++ b/src/types/role.ts
@@ -1,0 +1,42 @@
+import { EthereumAddress } from "../util/EthereumAddress";
+
+// Represents the owner of a role: either the literal network owner "system" or an Ethereum address
+export type OwnerIdentifier = "system" | EthereumAddress;
+
+export interface GrantRoleInput {
+  owner: OwnerIdentifier;
+  roleName: string;
+  wallets: EthereumAddress[];
+}
+
+export interface RevokeRoleInput {
+  owner: OwnerIdentifier;
+  roleName: string;
+  wallets: EthereumAddress[];
+}
+
+export interface AreMembersOfInput {
+  owner: OwnerIdentifier;
+  roleName: string;
+  wallets: EthereumAddress[];
+}
+
+export interface WalletMembership {
+  wallet: string; // lower-cased wallet address
+  isMember: boolean;
+}
+
+// Input parameters for listing role members with pagination
+export interface ListRoleMembersInput {
+  owner: OwnerIdentifier;
+  roleName: string;
+  limit?: number;  // max records to return (defaults enforced in SQL)
+  offset?: number; // offset for pagination (defaults enforced in SQL)
+}
+
+// The shape of a role member record as returned by list_role_members.
+export interface RoleMember {
+  wallet: string;      // Wallet address in lowercase
+  grantedAt: number;   // Block height when granted
+  grantedBy: string;   // Wallet address that performed the grant
+} 


### PR DESCRIPTION
### What & Why
- Introduce `RoleManagement` contract wrapper (`grantRole`, `revokeRole`, `areMembersOf`, `listRoleMembers`).
- Expose high-level helpers on `TNClient` for the same operations.
- Add typed interfaces in `src/types/role.ts`.
- Export new API via `index.common.ts`.

### Issues
- fixes #87
- fixes #86

### Tests
Compilation passes; integration tests will be added in a follow-up PR.