### PR TITLE
chore: set default timeout of 30s

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -31,6 +31,17 @@ const client = createClient({
 });
 ```
 
+### Timeout
+
+All network calls have a timeout. You can override it with the `timeout` option:
+
+```typescript
+const client = new NodeTNClient({
+  // …other options…
+  timeout: 45000, // Example of setting timeout to 45 seconds
+});
+```
+
 ## Stream Identification
 
 ### `StreamId.generate(name: string): Promise<StreamId>`

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -10,6 +10,7 @@ const client = new NodeTNClient({
         signer: wallet,
     },
     chainId: "tn-v2",
+    timeout: 30000,
 });
 
 // Create a stream locator for the AI Index

--- a/src/client/browserClient.ts
+++ b/src/client/browserClient.ts
@@ -7,6 +7,7 @@ export class BrowserTNClient extends BaseTNClient<EnvironmentType.BROWSER> {
     super(options);
     this.kwilClient = new WebKwil({
       ...options,
+      timeout: options.timeout ?? 30000,
       kwilProvider: options.endpoint,
     });
   }

--- a/src/client/nodeClient.ts
+++ b/src/client/nodeClient.ts
@@ -7,6 +7,7 @@ export class NodeTNClient extends BaseTNClient<EnvironmentType.NODE> {
     super(options);
     this.kwilClient = new NodeKwil({
       ...options,
+      timeout: options.timeout ?? 30000,
       kwilProvider: options.endpoint,
     });
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

explicitly set timeout to 30s

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/truf-data-provider/issues/717

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
