### PR TITLE
feat: comprehensive cache support with enhanced metadata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+NODE_REPO_DIR=path/to/your/node/repo

--- a/package.json
+++ b/package.json
@@ -46,10 +46,12 @@
     "prepublishOnly": "npm run build",
     "tag:dev": "pnpm version 0.0.0-dev-$(date +%Y%m%d%H%M%S) --no-git-tag-version",
     "publish:dev": "pnpm publish --tag dev --no-git-checks",
-    "test": "vitest"
+    "test": "vitest",
+    "test:unit": "vitest src/ --run",
+    "test:integration": "vitest tests/integration/ --run"
   },
   "dependencies": {
-    "@trufnetwork/kwil-js": "^0.9.5",
+    "@trufnetwork/kwil-js": "^0.9.6-rc.1",
     "crypto-hash": "^3.1.0",
     "ethers": "^6.13.5",
     "lodash": "^4.17.21",

--- a/src/contracts-api/action.ts
+++ b/src/contracts-api/action.ts
@@ -195,7 +195,20 @@ export class Action {
       value: row.value,
     }));
     
-    const cache = CacheMetadataParser.extractFromResponse(result);
+    let cache = CacheMetadataParser.extractFromResponse(result);
+    
+    // Enhance cache metadata with SDK-provided context
+    if (cache) {
+      cache = {
+        ...cache,
+        streamId: stream.streamId.getId(),
+        dataProvider: stream.dataProvider.getAddress(),
+        from: options?.from,
+        to: options?.to,
+        frozenAt: options?.frozenAt,
+        rowsServed: data.length
+      };
+    }
     
     return {
       data,
@@ -287,7 +300,20 @@ export class Action {
       value: row.value,
     }));
     
-    const cache = CacheMetadataParser.extractFromResponse(result);
+    let cache = CacheMetadataParser.extractFromResponse(result);
+    
+    // Enhance cache metadata with SDK-provided context
+    if (cache) {
+      cache = {
+        ...cache,
+        streamId: stream.streamId.getId(),
+        dataProvider: stream.dataProvider.getAddress(),
+        from: options?.from,
+        to: options?.to,
+        frozenAt: options?.frozenAt,
+        rowsServed: data.length
+      };
+    }
     
     return {
       data,
@@ -411,7 +437,18 @@ export class Action {
       value: rawData[0].value,
     } : null;
     
-    const cache = CacheMetadataParser.extractFromResponse(result);
+    let cache = CacheMetadataParser.extractFromResponse(result);
+    
+    // Enhance cache metadata with SDK-provided context
+    if (cache) {
+      cache = {
+        ...cache,
+        streamId: stream.streamId.getId(),
+        dataProvider: stream.dataProvider.getAddress(),
+        frozenAt: options?.frozenAt,
+        rowsServed: data ? 1 : 0
+      };
+    }
     
     return {
       data,
@@ -750,7 +787,20 @@ export class Action {
       value: row.value,
     }));
     
-    const cache = CacheMetadataParser.extractFromResponse(result);
+    let cache = CacheMetadataParser.extractFromResponse(result);
+    
+    // Enhance cache metadata with SDK-provided context
+    if (cache) {
+      cache = {
+        ...cache,
+        streamId: stream.streamId.getId(),
+        dataProvider: stream.dataProvider.getAddress(),
+        from: options.from,
+        to: options.to,
+        frozenAt: options.frozenAt,
+        rowsServed: data.length
+      };
+    }
     
     return {
       data,

--- a/src/types/cache.test.ts
+++ b/src/types/cache.test.ts
@@ -3,6 +3,7 @@ import { CacheError } from './cache';
 import type { 
   CacheMetadata, 
   CacheAwareResponse, 
+  CacheMetadataCollection,
   GetRecordOptions, 
   GetIndexOptions, 
   GetIndexChangeOptions, 
@@ -21,6 +22,67 @@ describe('Cache Types', () => {
       const metadata: CacheMetadata = { hit: false };
       expect(metadata.hit).toBe(false);
       expect(metadata.cachedAt).toBeUndefined();
+    });
+
+    it('should allow enhanced cache metadata with all fields', () => {
+      const metadata: CacheMetadata = {
+        hit: true,
+        cacheDisabled: false,
+        cachedAt: 1609459200,
+        streamId: 'test-stream',
+        dataProvider: '0x123456789abcdef',
+        from: 1609459100,
+        to: 1609459300,
+        frozenAt: 1609459250,
+        rowsServed: 10
+      };
+      
+      expect(metadata.hit).toBe(true);
+      expect(metadata.cacheDisabled).toBe(false);
+      expect(metadata.cachedAt).toBe(1609459200);
+      expect(metadata.streamId).toBe('test-stream');
+      expect(metadata.dataProvider).toBe('0x123456789abcdef');
+      expect(metadata.from).toBe(1609459100);
+      expect(metadata.to).toBe(1609459300);
+      expect(metadata.frozenAt).toBe(1609459250);
+      expect(metadata.rowsServed).toBe(10);
+    });
+
+    it('should allow partial enhanced metadata', () => {
+      const metadata: CacheMetadata = {
+        hit: true,
+        cacheDisabled: true,
+        streamId: 'partial-stream'
+      };
+      
+      expect(metadata.hit).toBe(true);
+      expect(metadata.cacheDisabled).toBe(true);
+      expect(metadata.streamId).toBe('partial-stream');
+      expect(metadata.cachedAt).toBeUndefined();
+    });
+  });
+
+  describe('CacheMetadataCollection', () => {
+    it('should allow valid cache metadata collection', () => {
+      const collection: CacheMetadataCollection = {
+        totalQueries: 5,
+        cacheHits: 3,
+        cacheMisses: 2,
+        cacheHitRate: 0.6,
+        totalRowsServed: 100,
+        entries: [
+          { hit: true, rowsServed: 30 },
+          { hit: false, rowsServed: 25 },
+          { hit: true, rowsServed: 45 }
+        ]
+      };
+      
+      expect(collection.totalQueries).toBe(5);
+      expect(collection.cacheHits).toBe(3);
+      expect(collection.cacheMisses).toBe(2);
+      expect(collection.cacheHitRate).toBe(0.6);
+      expect(collection.totalRowsServed).toBe(100);
+      expect(collection.entries).toHaveLength(3);
     });
   });
 

--- a/src/types/cache.ts
+++ b/src/types/cache.ts
@@ -10,8 +10,24 @@
 export interface CacheMetadata {
   /** Whether the data came from cache */
   hit: boolean;
+  /** Whether cache was disabled for this query */
+  cacheDisabled?: boolean;
   /** Unix timestamp when data was cached (optional) */
   cachedAt?: number;
+  
+  // SDK-provided context (optional)
+  /** Stream ID used in the query */
+  streamId?: string;
+  /** Data provider address */
+  dataProvider?: string;
+  /** Start time of the query range */
+  from?: number;
+  /** End time of the query range */
+  to?: number;
+  /** Frozen time for historical queries */
+  frozenAt?: number;
+  /** Number of rows returned */
+  rowsServed?: number;
 }
 
 /**
@@ -93,6 +109,24 @@ export interface CacheAwareResponse<T> {
   cache?: CacheMetadata;
   /** Action logs for debugging (optional) */
   logs?: string[];
+}
+
+/**
+ * Aggregated cache metadata from multiple operations
+ */
+export interface CacheMetadataCollection {
+  /** Total number of queries performed */
+  totalQueries: number;
+  /** Number of cache hits */
+  cacheHits: number;
+  /** Number of cache misses */
+  cacheMisses: number;
+  /** Cache hit rate (0-1) */
+  cacheHitRate: number;
+  /** Total rows served across all queries */
+  totalRowsServed: number;
+  /** Individual metadata entries */
+  entries: CacheMetadata[];
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

  - Add enhanced CacheMetadata interface with SDK context fields (streamId, dataProvider, from, to, frozenAt, rowsServed)
  - Implement CacheMetadataCollection for aggregating cache statistics
  - Add cache metadata aggregation functionality in CacheMetadataParser
  - Update all action methods to populate enhanced cache metadata with SDK-provided context
  - Fix cache metadata extraction to handle cached_at for both hits and misses
  - Update kwil-js dependency to v0.9.6-rc.1 to resolve integration test failures
  - Add test scripts for unit and integration test separation
  - Add comprehensive test coverage for enhanced cache features


## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/sdk-js/issues/106

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

All test passing using vitest