### PR TITLE
chore: parse logs correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test:integration": "vitest tests/integration/ --run"
   },
   "dependencies": {
-    "@trufnetwork/kwil-js": "^0.9.6-rc.1",
+    "@trufnetwork/kwil-js": "^0.9.6-rc.2",
     "crypto-hash": "^3.1.0",
     "ethers": "^6.13.5",
     "lodash": "^4.17.21",

--- a/src/contracts-api/action.ts
+++ b/src/contracts-api/action.ts
@@ -213,7 +213,7 @@ export class Action {
     return {
       data,
       cache: cache || undefined,
-      logs: result.data ? [JSON.stringify(result.data)] : undefined
+      logs: result.data?.logs ? CacheMetadataParser.parseLogsForMetadata(result.data.logs) : undefined,
     };
   }
 

--- a/src/contracts-api/action.ts
+++ b/src/contracts-api/action.ts
@@ -318,7 +318,7 @@ export class Action {
     return {
       data,
       cache: cache || undefined,
-      logs: result.data ? [JSON.stringify(result.data)] : undefined
+      logs: result.data?.logs ? CacheMetadataParser.parseLogsForMetadata(result.data.logs) : undefined
     };
   }
 
@@ -453,7 +453,7 @@ export class Action {
     return {
       data,
       cache: cache || undefined,
-      logs: result.data ? [JSON.stringify(result.data)] : undefined
+      logs: result.data?.logs ? CacheMetadataParser.parseLogsForMetadata(result.data.logs) : undefined
     };
   }
 
@@ -805,7 +805,7 @@ export class Action {
     return {
       data,
       cache: cache || undefined,
-      logs: result.data ? [JSON.stringify(result.data)] : undefined
+      logs: result.data?.logs ? CacheMetadataParser.parseLogsForMetadata(result.data.logs) : undefined
     };
   }
 

--- a/src/contracts-api/cache.integration.test.ts
+++ b/src/contracts-api/cache.integration.test.ts
@@ -3,6 +3,7 @@ import { Action } from './action';
 import { EthereumAddress } from '../util/EthereumAddress';
 import { StreamId } from '../util/StreamId';
 import type { StreamLocator } from '../types/stream';
+import { CacheMetadata } from '../types/cache';
 
 // Mock Kwil client
 const mockKwilClient = {
@@ -35,7 +36,8 @@ describe('Cache Integration Tests', () => {
           result: [
             { event_time: 1609459200, value: '100' },
             { event_time: 1609459260, value: '101' }
-          ]
+          ],
+          logs: '1. cache_hit: true\n2. other log\n111. cache_miss: false'
         }
       };
 
@@ -69,7 +71,7 @@ describe('Cache Integration Tests', () => {
           { eventTime: 1609459260, value: '101' }
         ],
         cache: undefined,
-        logs: [JSON.stringify(mockResponse.data)]
+        logs: ['cache_hit: true', 'other log', 'cache_miss: false']
       });
     });
 
@@ -79,7 +81,8 @@ describe('Cache Integration Tests', () => {
         data: {
           result: [
             { event_time: 1609459200, value: '100' }
-          ]
+          ],
+          logs: '1. {"cache_hit":true,"cache_disabled":false,"cache_height":148670}'
         }
       };
 
@@ -97,6 +100,20 @@ describe('Cache Integration Tests', () => {
       expect(result.data).toEqual([
         { eventTime: 1609459200, value: '100' }
       ]);
+
+      expect(result.cache).toMatchObject({
+        hit: true,
+        cacheDisabled: false,
+        height: 148670,
+        dataProvider: '0x1234567890123456789012345678901234567890',
+        from: undefined,
+        frozenAt: undefined,
+        rowsServed: 1,
+        streamId: 'test-stream',
+        to: undefined
+      } as CacheMetadata);
+
+      expect(result.logs).toMatchObject(['{"cache_hit":true,"cache_disabled":false,"cache_height":148670}']);
     });
 
     it('should omit useCache parameter when not provided', async () => {

--- a/src/util/cacheMetadataParser.test.ts
+++ b/src/util/cacheMetadataParser.test.ts
@@ -127,6 +127,45 @@ describe('CacheMetadataParser', () => {
         height: undefined
       });
     });
+
+    it('should handle logs with prepended numeric prefixes', () => {
+      const logs = ['1. {"cache_hit": true, "cache_height": 123456}\n2. some other log\n3. {"cache_hit": false}'];
+      const metadata = CacheMetadataParser.extractFromLogs(logs);
+      // Should extract the first cache metadata found (cache hit)
+      expect(metadata).toEqual({
+        hit: true,
+        cacheDisabled: undefined,
+        height: 123456
+      });
+    });
+
+    it('should handle array of logs with prepended numeric prefixes', () => {
+      const logs = [
+        '1. normal log line',
+        '2. {"cache_hit": false, "cache_disabled": true}',
+        '3. another log line'
+      ];
+      const metadata = CacheMetadataParser.extractFromLogs(logs);
+      expect(metadata).toEqual({
+        hit: false,
+        cacheDisabled: true,
+        height: undefined
+      });
+    });
+
+    it('should handle mixed format logs (some with prefixes, some without)', () => {
+      const logs = [
+        'normal log without prefix',
+        '1. {"cache_hit": true}',
+        'another log without prefix'
+      ];
+      const metadata = CacheMetadataParser.extractFromLogs(logs);
+      expect(metadata).toEqual({
+        hit: true,
+        cacheDisabled: undefined,
+        height: undefined
+      });
+    });
   });
 
   describe('isValidCacheMetadata', () => {

--- a/src/util/cacheMetadataParser.ts
+++ b/src/util/cacheMetadataParser.ts
@@ -10,7 +10,7 @@ export class CacheMetadataParser {
    * @param logsInput - The logs string or array to parse
    * @returns Array of clean log lines
    */
-  private static parseLogsForMetadata(logsInput: string | string[]): string[] {
+  static parseLogsForMetadata(logsInput: string | string[]): string[] {
     const logs: string[] = [];
     const logArray = Array.isArray(logsInput) ? logsInput : [logsInput];
     
@@ -151,12 +151,17 @@ export class CacheMetadataParser {
    * @returns Cache metadata if found, null otherwise
    */
   static extractFromResponse(response: any): CacheMetadata | null {
-    // Check if response has logs
-    if (!response || !response.logs) {
-      return null;
+    // Check if response has logs (new structure from kwil-js)
+    if (response && response.data && response.data.logs) {
+      return this.extractFromLogs(response.data.logs);
     }
     
-    return this.extractFromLogs(response.logs);
+    // Fallback: check if response has logs directly (for backward compatibility)
+    if (response && response.logs) {
+      return this.extractFromLogs(response.logs);
+    }
+    
+    return null;
   }
   
   /**

--- a/src/util/cacheMetadataParser.ts
+++ b/src/util/cacheMetadataParser.ts
@@ -6,53 +6,86 @@ import { CacheMetadata, CacheMetadataCollection } from '../types/cache';
  */
 export class CacheMetadataParser {
   /**
+   * Parses logs and removes prepended numeric prefixes (e.g., "1. ", "2. ")
+   * @param logsInput - The logs string or array to parse
+   * @returns Array of clean log lines
+   */
+  private static parseLogsForMetadata(logsInput: string | string[]): string[] {
+    const logs: string[] = [];
+    const logArray = Array.isArray(logsInput) ? logsInput : [logsInput];
+    
+    for (const log of logArray) {
+      if (!log || typeof log !== 'string') {
+        continue;
+      }
+      
+      const lines = log.split('\n');
+      for (const line of lines) {
+        const trimmedLine = line.trim();
+        if (!trimmedLine) {
+          continue;
+        }
+        
+        // Check for prepended numeric format (e.g., "1. ", "2. ")
+        const dotSpaceIndex = trimmedLine.indexOf('. ');
+        if (dotSpaceIndex > 0) {
+          const prefix = trimmedLine.substring(0, dotSpaceIndex);
+          // Check if prefix is a number
+          if (/^\d+$/.test(prefix)) {
+            const cleanLine = trimmedLine.substring(dotSpaceIndex + 2).trim();
+            if (cleanLine) {
+              logs.push(cleanLine);
+            }
+            continue;
+          }
+        }
+        
+        // If no prepended format found, add the line as-is
+        logs.push(trimmedLine);
+      }
+    }
+    
+    return logs;
+  }
+
+  /**
    * Extracts cache metadata from action logs
    * @param logs - The action logs returned from the backend (may be a single string or array)
    * @returns Cache metadata if found, null otherwise
    */
   static extractFromLogs(logs: string | string[]): CacheMetadata | null {
-    // Handle both single string and array of strings
-    const logArray = Array.isArray(logs) ? logs : [logs];
+    // Parse logs and remove prepended numeric prefixes
+    const logLines = this.parseLogsForMetadata(logs);
     
-    for (const log of logArray) {
-      // Split single log string on newlines to handle multi-line logs
-      const logLines = log.split('\n');
-      
-      for (const line of logLines) {
-        // Skip empty lines
-        if (!line.trim()) {
-          continue;
-        }
-        
-        // Look for cache-related log entries
-        if (line.includes('cache_hit')) {
-          try {
-            // Try to parse as JSON
-            const logData = JSON.parse(line);
-            
-            // Check if this is a cache hit entry
-            if (logData.cache_hit === true) {
-              return {
-                hit: true,
-                cacheDisabled: logData.cache_disabled,
-                height: logData.cache_height ? Number(logData.cache_height) : undefined
-              };
-            }
-            
-            // Cache miss case
-            if (logData.cache_hit === false) {
-              return {
-                hit: false,
-                cacheDisabled: logData.cache_disabled,
-                height: undefined
-              };
-            }
-            
-          } catch (error) {
-            // If JSON parsing fails, continue checking other logs
-            // This is expected for non-JSON log entries
-            continue;
+    for (const line of logLines) {
+      // Look for cache-related log entries
+      if (line.includes('cache_hit')) {
+        try {
+          // Try to parse as JSON
+          const logData = JSON.parse(line);
+          
+          // Check if this is a cache hit entry
+          if (logData.cache_hit === true) {
+            return {
+              hit: true,
+              cacheDisabled: logData.cache_disabled,
+              height: logData.cache_height ? Number(logData.cache_height) : undefined
+            };
           }
+          
+          // Cache miss case
+          if (logData.cache_hit === false) {
+            return {
+              hit: false,
+              cacheDisabled: logData.cache_disabled,
+              height: undefined
+            };
+          }
+          
+        } catch (error) {
+          // If JSON parsing fails, continue checking other logs
+          // This is expected for non-JSON log entries
+          continue;
         }
       }
     }


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail; use bullet points. -->

* Added functionality to handle logs with prepended numeric prefixes, improving the extraction of cache metadata.
* Introduced new test cases to validate the handling of various log formats, including logs with and without prefixes.
* Refactored the log extraction logic to ensure robust parsing and metadata retrieval from action logs.


## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

- fix #113 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved log parsing to better extract metadata from logs with numeric prefixes and new response structures.

* **Bug Fixes**
  * Enhanced handling of logs to ensure accurate extraction of cache metadata, even from mixed or prefixed log formats.

* **Tests**
  * Added new test cases to verify correct parsing of logs with numeric prefixes and mixed formats.
  * Updated cache integration tests to validate detailed cache metadata extraction and log handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->