### PR TITLE
feat: batch taxonomy queries for efficient stream synchronization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,19 @@
+# Node repository directory (required for some integration tests that use setupTrufNetwork)
 NODE_REPO_DIR=path/to/your/node/repo
+
+# Integration test configuration
+# These variables allow you to customize the network endpoint for integration tests
+# The taxonomy querying tests use these to connect to the network
+TEST_ENDPOINT=https://gateway.mainnet.truf.network
+TEST_CHAIN_ID=tn-v2
+
+# For local testing (if you have a local TRUF Network node running)
+# TEST_ENDPOINT=http://localhost:8484
+# TEST_CHAIN_ID=your-local-chain-id
+
+# Usage examples:
+# Run taxonomy integration tests with mainnet:
+#   npx vitest run tests/integration/taxonomyQuerying.test.ts
+#
+# Run with custom endpoint:
+#   TEST_ENDPOINT=http://localhost:8484 npx vitest run tests/integration/taxonomyQuerying.test.ts

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,6 +22,9 @@ pnpm install
 The `index.ts` file demonstrates how to:
 - Connect to the Truf Network
 - Retrieve records from the AI Index stream
+- Query taxonomies using new height-based querying methods
+- Perform batch processing for multiple streams
+- Use incremental synchronization patterns
 
 To run:
 ```bash
@@ -31,8 +34,35 @@ pnpm start
 Example output:
 ```
 AI Index records: [ { eventTime: '1748908800', value: '102.407712690100000000' } ]
+
+=== Taxonomy Querying Examples ===
+Found 3 recent taxonomies:
+1. Stream: st123abc
+   Child: st456def
+   Weight: 0.75
+   Block Height: 1500
 ```
 Note: The actual values will vary as the AI Index is updated regularly.
+
+### Taxonomy Querying Example
+
+The `taxonomy_querying_example/` directory contains a comprehensive example demonstrating:
+- Height-based taxonomy querying for incremental synchronization
+- Batch processing for multiple streams
+- Pagination handling for large datasets
+- Latest-only filtering
+- Real-world use cases for explorer synchronization
+
+To run:
+```bash
+cd taxonomy_querying_example
+PRIVATE_KEY=your_private_key npm start
+```
+
+This example is particularly useful for:
+- Building blockchain explorers that need to sync taxonomy changes
+- Analytics systems that track stream composition over time
+- Monitoring tools that detect taxonomy updates
 
 ## Notes
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -9,5 +9,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "description": ""
+  "description": "",
+  "dependencies": {
+    "@trufnetwork/sdk-js": "file:../",
+    "tsx": "^4.20.3"
+  }
 }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -6,7 +6,7 @@ import { EnvironmentType } from "@trufnetwork/kwil-js/dist/core/enums";
 import { GenericResponse } from "@trufnetwork/kwil-js/dist/core/resreq";
 import { TxReceipt } from "@trufnetwork/kwil-js/dist/core/tx";
 import { TxInfoReceipt } from "@trufnetwork/kwil-js/dist/core/txQuery";
-import { ComposedAction } from "../contracts-api/composedAction";
+import { ComposedAction, ListTaxonomiesByHeightParams, GetTaxonomiesForStreamsParams, TaxonomyQueryResult } from "../contracts-api/composedAction";
 import { deployStream } from "../contracts-api/deployStream";
 import { deleteStream } from "../contracts-api/deleteStream";
 import { PrimitiveAction } from "../contracts-api/primitiveAction";
@@ -233,6 +233,52 @@ export abstract class BaseTNClient<T extends EnvironmentType> {
     async getLastTransactions(input: GetLastTransactionsInput): Promise<any[]> {
         return getLastTransactions(this.getKwilClient() as WebKwil | NodeKwil,this.getKwilSigner(),input);
     }
+
+  /**
+   * Lists taxonomies by height range for incremental synchronization.
+   * High-level wrapper for ComposedAction.listTaxonomiesByHeight()
+   * 
+   * @param params Height range and pagination parameters  
+   * @returns Promise resolving to taxonomy query results
+   * 
+   * @example
+   * ```typescript
+   * const taxonomies = await client.listTaxonomiesByHeight({
+   *   fromHeight: 1000,
+   *   toHeight: 2000,
+   *   limit: 100,
+   *   latestOnly: true
+   * });
+   * ```
+   */
+  async listTaxonomiesByHeight(params: ListTaxonomiesByHeightParams = {}): Promise<TaxonomyQueryResult[]> {
+    const composedAction = this.loadComposedAction();
+    return composedAction.listTaxonomiesByHeight(params);
+  }
+
+  /**
+   * Gets taxonomies for specific streams in batch.
+   * High-level wrapper for ComposedAction.getTaxonomiesForStreams()
+   * 
+   * @param params Stream locators and options
+   * @returns Promise resolving to taxonomy query results
+   * 
+   * @example
+   * ```typescript
+   * const streams = [
+   *   { dataProvider: provider1, streamId: streamId1 },
+   *   { dataProvider: provider2, streamId: streamId2 }
+   * ];
+   * const taxonomies = await client.getTaxonomiesForStreams({
+   *   streams,
+   *   latestOnly: true
+   * });
+   * ```
+   */
+  async getTaxonomiesForStreams(params: GetTaxonomiesForStreamsParams): Promise<TaxonomyQueryResult[]> {
+    const composedAction = this.loadComposedAction();
+    return composedAction.getTaxonomiesForStreams(params);
+  }
 
   /**
    * Get the default chain id for a provider. Use with caution, as this decreases the security of the TN.

--- a/src/contracts-api/composedAction.test.ts
+++ b/src/contracts-api/composedAction.test.ts
@@ -1,0 +1,348 @@
+import { describe, test, expect, vi } from 'vitest'
+import { ComposedAction } from './composedAction'
+import { EthereumAddress } from '../util/EthereumAddress'
+import { StreamId } from '../util/StreamId'
+
+describe('ComposedAction Taxonomy Query Methods', () => {
+  const createMockClient = (mockResponse: any) => ({
+    call: vi.fn().mockResolvedValue({
+      status: 200,
+      data: {
+        result: mockResponse
+      }
+    })
+  });
+
+  const mockSigner = {};
+
+  test('listTaxonomiesByHeight calls correct action with parameters', async () => {
+    const mockResponse = [
+      {
+        data_provider: '0x1234567890abcdef1234567890abcdef12345678',
+        stream_id: 'test-stream',
+        child_data_provider: '0xabcdef1234567890abcdef1234567890abcdef12',
+        child_stream_id: 'child-stream',
+        weight: '100.5',
+        created_at: 1000,
+        group_sequence: 1,
+        start_time: 1625097600
+      }
+    ];
+
+    const mockClient = createMockClient(mockResponse);
+    const composedAction = new ComposedAction(mockClient as any, mockSigner as any);
+
+    const result = await composedAction.listTaxonomiesByHeight({
+      fromHeight: 1000,
+      toHeight: 2000,
+      limit: 100,
+      offset: 10,
+      latestOnly: true
+    });
+
+    // Verify the call was made correctly
+    expect(mockClient.call).toHaveBeenCalledWith(
+      {
+        namespace: "main",
+        name: 'list_taxonomies_by_height',
+        inputs: {
+          $from_height: 1000,
+          $to_height: 2000,
+          $limit: 100,
+          $offset: 10,
+          $latest_only: true,
+        }
+      },
+      {}
+    );
+
+    // Verify response mapping
+    expect(result).toHaveLength(1);
+    expect(result[0].dataProvider.getAddress()).toBe('0x1234567890abcdef1234567890abcdef12345678');
+    expect(result[0].streamId.getId()).toBe('test-stream');
+    expect(result[0].childDataProvider.getAddress()).toBe('0xabcdef1234567890abcdef1234567890abcdef12');
+    expect(result[0].childStreamId.getId()).toBe('child-stream');
+    expect(result[0].weight).toBe('100.5');
+    expect(result[0].createdAt).toBe(1000);
+    expect(result[0].groupSequence).toBe(1);
+    expect(result[0].startTime).toBe(1625097600);
+  });
+
+  test('listTaxonomiesByHeight handles default parameters', async () => {
+    const mockClient = createMockClient([]);
+    const composedAction = new ComposedAction(mockClient as any, mockSigner as any);
+
+    await composedAction.listTaxonomiesByHeight({});
+
+    expect(mockClient.call).toHaveBeenCalledWith(
+      {
+        namespace: "main",
+        name: 'list_taxonomies_by_height',
+        inputs: {
+          $from_height: null,
+          $to_height: null,
+          $limit: null,
+          $offset: null,
+          $latest_only: null,
+        }
+      },
+      {}
+    );
+  });
+
+  test('listTaxonomiesByHeight handles empty parameters', async () => {
+    const mockClient = createMockClient([]);
+    const composedAction = new ComposedAction(mockClient as any, mockSigner as any);
+
+    await composedAction.listTaxonomiesByHeight();
+
+    expect(mockClient.call).toHaveBeenCalledWith(
+      {
+        namespace: "main",
+        name: 'list_taxonomies_by_height',
+        inputs: {
+          $from_height: null,
+          $to_height: null,
+          $limit: null,
+          $offset: null,
+          $latest_only: null,
+        }
+      },
+      {}
+    );
+  });
+
+  test('getTaxonomiesForStreams calls correct action with stream arrays', async () => {
+    const mockResponse = [
+      {
+        data_provider: '0x1111111111111111111111111111111111111111',
+        stream_id: 'stream-1',
+        child_data_provider: '0x2222222222222222222222222222222222222222',
+        child_stream_id: 'child-1',
+        weight: '50.0',
+        created_at: 2000,
+        group_sequence: 2,
+        start_time: 1625097700
+      }
+    ];
+
+    const mockClient = createMockClient(mockResponse);
+    const composedAction = new ComposedAction(mockClient as any, mockSigner as any);
+
+    const testStreams = [
+      {
+        dataProvider: EthereumAddress.fromString('0x1111111111111111111111111111111111111111').throw(),
+        streamId: StreamId.fromString('stream-1').throw()
+      },
+      {
+        dataProvider: EthereumAddress.fromString('0x3333333333333333333333333333333333333333').throw(),
+        streamId: StreamId.fromString('stream-2').throw()
+      }
+    ];
+
+    const result = await composedAction.getTaxonomiesForStreams({
+      streams: testStreams,
+      latestOnly: false
+    });
+
+    // Verify the call was made correctly
+    expect(mockClient.call).toHaveBeenCalledWith(
+      {
+        namespace: "main",
+        name: 'get_taxonomies_for_streams',
+        inputs: {
+          $data_providers: [
+            '0x1111111111111111111111111111111111111111',
+            '0x3333333333333333333333333333333333333333'
+          ],
+          $stream_ids: ['stream-1', 'stream-2'],
+          $latest_only: false,
+        }
+      },
+      {}
+    );
+
+    // Verify response mapping
+    expect(result).toHaveLength(1);
+    expect(result[0].dataProvider.getAddress()).toBe('0x1111111111111111111111111111111111111111');
+    expect(result[0].streamId.getId()).toBe('stream-1');
+    expect(result[0].weight).toBe('50.0');
+  });
+
+  test('getTaxonomiesForStreams handles empty stream array', async () => {
+    const mockClient = createMockClient([]);
+    const composedAction = new ComposedAction(mockClient as any, mockSigner as any);
+
+    const result = await composedAction.getTaxonomiesForStreams({
+      streams: [],
+      latestOnly: true
+    });
+
+    // Should return empty array without making network call
+    expect(mockClient.call).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  test('getTaxonomiesForStreams handles latestOnly parameter', async () => {
+    const mockClient = createMockClient([]);
+    const composedAction = new ComposedAction(mockClient as any, mockSigner as any);
+
+    const testStreams = [
+      {
+        dataProvider: EthereumAddress.fromString('0x1111111111111111111111111111111111111111').throw(),
+        streamId: StreamId.fromString('stream-1').throw()
+      }
+    ];
+
+    await composedAction.getTaxonomiesForStreams({
+      streams: testStreams,
+      latestOnly: true
+    });
+
+    expect(mockClient.call).toHaveBeenCalledWith(
+      {
+        namespace: "main",
+        name: 'get_taxonomies_for_streams',
+        inputs: expect.objectContaining({
+          $latest_only: true,
+        })
+      },
+      {}
+    );
+  });
+
+  test('getTaxonomiesForStreams handles default latestOnly parameter', async () => {
+    const mockClient = createMockClient([]);
+    const composedAction = new ComposedAction(mockClient as any, mockSigner as any);
+
+    const testStreams = [
+      {
+        dataProvider: EthereumAddress.fromString('0x1111111111111111111111111111111111111111').throw(),
+        streamId: StreamId.fromString('stream-1').throw()
+      }
+    ];
+
+    await composedAction.getTaxonomiesForStreams({
+      streams: testStreams
+    });
+
+    expect(mockClient.call).toHaveBeenCalledWith(
+      {
+        namespace: "main",
+        name: 'get_taxonomies_for_streams',
+        inputs: expect.objectContaining({
+          $latest_only: null,
+        })
+      },
+      {}
+    );
+  });
+
+  test('listTaxonomiesByHeight handles network error', async () => {
+    const mockClient = {
+      call: vi.fn().mockResolvedValue({
+        status: 500,
+        data: null
+      })
+    };
+
+    const composedAction = new ComposedAction(mockClient as any, mockSigner as any);
+
+    await expect(
+      composedAction.listTaxonomiesByHeight({
+        fromHeight: 1000,
+        toHeight: 2000
+      })
+    ).rejects.toThrow();
+  });
+
+  test('getTaxonomiesForStreams handles network error', async () => {
+    const mockClient = {
+      call: vi.fn().mockResolvedValue({
+        status: 404,
+        data: null
+      })
+    };
+
+    const composedAction = new ComposedAction(mockClient as any, mockSigner as any);
+
+    const testStreams = [
+      {
+        dataProvider: EthereumAddress.fromString('0x1111111111111111111111111111111111111111').throw(),
+        streamId: StreamId.fromString('stream-1').throw()
+      }
+    ];
+
+    await expect(
+      composedAction.getTaxonomiesForStreams({
+        streams: testStreams
+      })
+    ).rejects.toThrow();
+  });
+
+  test('methods handle multiple results correctly', async () => {
+    const mockResponse = [
+      {
+        data_provider: '0x1111111111111111111111111111111111111111',
+        stream_id: 'stream-1',
+        child_data_provider: '0x2222222222222222222222222222222222222222',
+        child_stream_id: 'child-1',
+        weight: '50.0',
+        created_at: 2000,
+        group_sequence: 1,
+        start_time: 1625097600
+      },
+      {
+        data_provider: '0x1111111111111111111111111111111111111111',
+        stream_id: 'stream-1',
+        child_data_provider: '0x3333333333333333333333333333333333333333',
+        child_stream_id: 'child-2',
+        weight: '25.5',
+        created_at: 2000,
+        group_sequence: 1,
+        start_time: 1625097600
+      }
+    ];
+
+    const mockClient = createMockClient(mockResponse);
+    const composedAction = new ComposedAction(mockClient as any, mockSigner as any);
+
+    const result = await composedAction.listTaxonomiesByHeight({ limit: 10 });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].childStreamId.getId()).toBe('child-1');
+    expect(result[1].childStreamId.getId()).toBe('child-2');
+    expect(result[0].weight).toBe('50.0');
+    expect(result[1].weight).toBe('25.5');
+  });
+
+  test('methods handle address parsing correctly', async () => {
+    const mockResponse = [
+      {
+        data_provider: '0x1234567890abcdef1234567890abcdef12345678',
+        stream_id: 'test-stream',
+        child_data_provider: '0xabcdef1234567890abcdef1234567890abcdef12',
+        child_stream_id: 'child-stream',
+        weight: '100.0',
+        created_at: 1000,
+        group_sequence: 1,
+        start_time: 1625097600
+      }
+    ];
+
+    const mockClient = createMockClient(mockResponse);
+    const composedAction = new ComposedAction(mockClient as any, mockSigner as any);
+
+    const result = await composedAction.listTaxonomiesByHeight();
+
+    expect(result[0].dataProvider).toBeInstanceOf(EthereumAddress);
+    expect(result[0].streamId).toBeInstanceOf(StreamId);
+    expect(result[0].childDataProvider).toBeInstanceOf(EthereumAddress);
+    expect(result[0].childStreamId).toBeInstanceOf(StreamId);
+    
+    expect(result[0].dataProvider.getAddress()).toBe('0x1234567890abcdef1234567890abcdef12345678');
+    expect(result[0].streamId.getId()).toBe('test-stream');
+    expect(result[0].childDataProvider.getAddress()).toBe('0xabcdef1234567890abcdef1234567890abcdef12');
+    expect(result[0].childStreamId.getId()).toBe('child-stream');
+  });
+});

--- a/src/index.common.ts
+++ b/src/index.common.ts
@@ -7,7 +7,7 @@ export type { StreamLocator } from "./types/stream";
 export type { StreamRecord } from "./contracts-api/action";
 export type { GetRecordInput, GetFirstRecordInput } from "./contracts-api/action";
 export type { InsertRecordInput } from "./contracts-api/primitiveAction";
-export type { TaxonomySet, TaxonomyItem } from "./contracts-api/composedAction";
+export type { TaxonomySet, TaxonomyItem, ListTaxonomiesByHeightParams, GetTaxonomiesForStreamsParams, TaxonomyQueryResult } from "./contracts-api/composedAction";
 
 // Utility types and classes
 export { StreamId } from "./util/StreamId";

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,141 @@
+# Integration Tests
+
+This directory contains integration tests for the TRUF Network SDK.
+
+## Test Types
+
+### 1. Node-Dependent Tests (Require Local Setup)
+Most integration tests use `setupTrufNetwork()` and require:
+- @node repository available locally
+- Docker containers for PostgreSQL and TN-DB
+- Complete local node deployment with migrations
+
+**Examples:**
+- `primitiveStream.test.ts`
+- `composedStream.test.ts`
+- `roleManagement.test.ts`
+
+**Setup Required:**
+```bash
+# Set NODE_REPO_DIR in .env
+NODE_REPO_DIR=/path/to/trufnetwork/node
+
+# Run tests
+npm run test:integration
+```
+
+### 2. Network-Independent Tests (Standalone)
+Some tests work directly against any TRUF Network endpoint without local setup.
+
+**Examples:**
+- `taxonomyQuerying.test.ts` ✨ (New)
+
+**Benefits:**
+- No @node repository dependency
+- No Docker containers needed
+- Can test against mainnet or any endpoint
+- Faster to set up and run
+
+## Environment Configuration
+
+Use `.env` or environment variables to customize test behavior:
+
+```bash
+# Default: Uses mainnet
+TEST_ENDPOINT=https://gateway.mainnet.truf.network
+TEST_CHAIN_ID=tn-v2
+
+# Or use local node
+TEST_ENDPOINT=http://localhost:8484
+TEST_CHAIN_ID=your-chain-id
+```
+
+## Running Tests
+
+### All Integration Tests (Requires Local Setup)
+```bash
+npm run test:integration
+```
+
+### Specific Test Files
+```bash
+# Node-independent taxonomy tests
+npx vitest run tests/integration/taxonomyQuerying.test.ts
+
+# With custom endpoint
+TEST_ENDPOINT=https://gateway.mainnet.truf.network \
+npx vitest run tests/integration/taxonomyQuerying.test.ts
+```
+
+### Individual Test Cases
+```bash
+npx vitest run -t "listTaxonomiesByHeight returns expected structure"
+```
+
+## Writing New Integration Tests
+
+### For New Functionality That Requires Node Setup
+Follow the existing pattern:
+```typescript
+import { setupTrufNetwork } from './utils'
+
+describe('My New Feature Tests', () => {
+  setupTrufNetwork(); // Handles Docker containers and node setup
+  
+  // Your tests here
+});
+```
+
+### For Query-Only Functionality
+Use the standalone pattern (recommended when possible):
+```typescript
+import { Wallet } from 'ethers'
+import { NodeTNClient } from '../../src/client/nodeClient'
+
+describe('My Query Tests', () => {
+  let client: NodeTNClient;
+
+  beforeEach(async () => {
+    const wallet = new Wallet("0x...");
+    const endpoint = process.env.TEST_ENDPOINT || "https://gateway.mainnet.truf.network";
+    const chainId = process.env.TEST_CHAIN_ID || "tn-v2";
+
+    client = new NodeTNClient({
+      endpoint,
+      signerInfo: { address: wallet.address, signer: wallet },
+      chainId,
+      timeout: 30000,
+    });
+  });
+
+  // Your tests here
+});
+```
+
+## Troubleshooting
+
+### "No actions found for namespace 'main'" Error
+This typically means:
+1. The node doesn't have the required actions deployed
+2. The node is not fully initialized
+3. Network connectivity issues
+
+### "Transaction failed: Caller is not the owner or member of manager role" Error  
+This means:
+1. The test wallet doesn't have required permissions (expected for read-only tests)
+2. You're testing against a network where the wallet doesn't have roles
+
+### Tests Timeout or Fail to Connect
+1. Check `TEST_ENDPOINT` is accessible
+2. Verify network connectivity
+3. Try with a different endpoint
+4. Check if the endpoint supports the required actions
+
+## Best Practices
+
+1. **Use environment variables** for configuration instead of hardcoding endpoints
+2. **Make tests resilient** to different data sets (mainnet vs local vs testnet)
+3. **Handle serialization differences** (string vs number types from different networks)
+4. **Test with realistic data** when possible rather than just mocked data
+5. **Keep tests independent** - don't rely on specific existing data when possible
+6. **Add appropriate timeouts** for network calls (30+ seconds for integration tests)

--- a/tests/integration/taxonomyQuerying.test.ts
+++ b/tests/integration/taxonomyQuerying.test.ts
@@ -1,0 +1,238 @@
+import { describe, test, expect, beforeEach } from 'vitest'
+import { NodeTNClient } from '../../src/client/nodeClient'
+import { ComposedAction } from '../../src/contracts-api/composedAction'
+import { StreamId } from '../../src/util/StreamId'
+import { EthereumAddress } from '../../src/util/EthereumAddress'
+import { Wallet } from 'ethers'
+
+describe('Taxonomy Querying Integration Tests', () => {
+  let client: NodeTNClient;
+  let composedAction: ComposedAction;
+
+  beforeEach(async () => {
+    // Use a simple setup that doesn't require node repo dependencies
+    const wallet = new Wallet("0x0000000000000000000000000000000000000000100000000100000000000001");
+    const endpoint = process.env.TEST_ENDPOINT || "https://gateway.mainnet.truf.network";
+    const chainId = process.env.TEST_CHAIN_ID || "tn-v2";
+
+    client = new NodeTNClient({
+      endpoint,
+      signerInfo: {
+        address: wallet.address,
+        signer: wallet,
+      },
+      chainId,
+      timeout: 30000,
+    });
+    
+    composedAction = client.loadComposedAction();
+  });
+
+  test('listTaxonomiesByHeight returns expected structure', async () => {
+    const result = await composedAction.listTaxonomiesByHeight({
+      limit: 10,
+      latestOnly: false
+    });
+
+    expect(Array.isArray(result)).toBe(true);
+    
+    // If we have results, verify structure
+    if (result.length > 0) {
+      const firstResult = result[0];
+      expect(firstResult).toHaveProperty('dataProvider');
+      expect(firstResult).toHaveProperty('streamId');
+      expect(firstResult).toHaveProperty('childDataProvider');
+      expect(firstResult).toHaveProperty('childStreamId');
+      expect(firstResult).toHaveProperty('weight');
+      expect(firstResult).toHaveProperty('createdAt');
+      expect(firstResult).toHaveProperty('groupSequence');
+      expect(firstResult).toHaveProperty('startTime');
+      
+      expect(firstResult.dataProvider).toBeInstanceOf(EthereumAddress);
+      expect(firstResult.streamId).toBeInstanceOf(StreamId);
+      expect(firstResult.childDataProvider).toBeInstanceOf(EthereumAddress);
+      expect(firstResult.childStreamId).toBeInstanceOf(StreamId);
+      expect(typeof firstResult.weight).toBe('string');
+      // Handle both string and number types (depends on serialization)
+      expect(['number', 'string']).toContain(typeof firstResult.createdAt);
+      expect(['number', 'string']).toContain(typeof firstResult.groupSequence);  
+      expect(['number', 'string']).toContain(typeof firstResult.startTime);
+    }
+  });
+
+  test('listTaxonomiesByHeight handles pagination parameters', async () => {
+    const page1 = await composedAction.listTaxonomiesByHeight({
+      limit: 5,
+      offset: 0
+    });
+    
+    const page2 = await composedAction.listTaxonomiesByHeight({
+      limit: 5,
+      offset: 5
+    });
+
+    expect(page1.length).toBeLessThanOrEqual(5);
+    expect(page2.length).toBeLessThanOrEqual(5);
+    
+    // Verify no overlap if both pages have results (with realistic data this might not always be true)
+    if (page1.length > 0 && page2.length > 0) {
+      const page1Ids = page1.map(r => `${r.dataProvider.getAddress()}_${r.streamId.getId()}_${r.childStreamId.getId()}`);
+      const page2Ids = page2.map(r => `${r.dataProvider.getAddress()}_${r.streamId.getId()}_${r.childStreamId.getId()}`);
+      const overlap = page1Ids.filter(id => page2Ids.includes(id));
+      // With real data, some overlap is possible if we don't have enough unique results
+      expect(overlap.length).toBeLessThanOrEqual(Math.min(page1.length, page2.length));
+    }
+  });
+
+  test('listTaxonomiesByHeight handles height range filtering', async () => {
+    // Use a fixed height range that we know has data
+    const filteredResults = await composedAction.listTaxonomiesByHeight({
+      fromHeight: 180000,
+      toHeight: 185000,
+      limit: 100
+    });
+    
+    expect(Array.isArray(filteredResults)).toBe(true);
+    
+    // If we have results, verify they're in range
+    for (const result of filteredResults) {
+      const height = Number(result.createdAt); // Handle string/number conversion
+      expect(height).toBeGreaterThanOrEqual(180000);
+      expect(height).toBeLessThanOrEqual(185000);
+    }
+  });
+
+  test('listTaxonomiesByHeight latest_only flag works', async () => {
+    const allResults = await composedAction.listTaxonomiesByHeight({
+      latestOnly: false,
+      limit: 100
+    });
+    
+    const latestOnly = await composedAction.listTaxonomiesByHeight({
+      latestOnly: true,
+      limit: 100
+    });
+
+    // Latest only should return same or fewer results
+    expect(latestOnly.length).toBeLessThanOrEqual(allResults.length);
+  });
+
+  test('getTaxonomiesForStreams handles empty stream array', async () => {
+    const result = await composedAction.getTaxonomiesForStreams({
+      streams: [],
+      latestOnly: true
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  test('getTaxonomiesForStreams returns expected structure', async () => {
+    // First get some streams to test with
+    const allTaxonomies = await composedAction.listTaxonomiesByHeight({
+      limit: 10,
+      latestOnly: true
+    });
+
+    if (allTaxonomies.length > 0) {
+      // Use first stream as test case
+      const testStream = {
+        dataProvider: allTaxonomies[0].dataProvider,
+        streamId: allTaxonomies[0].streamId
+      };
+
+      const result = await composedAction.getTaxonomiesForStreams({
+        streams: [testStream],
+        latestOnly: true
+      });
+
+      expect(Array.isArray(result)).toBe(true);
+      
+      // All results should be for the requested stream
+      for (const taxonomy of result) {
+        expect(taxonomy.dataProvider.getAddress()).toBe(testStream.dataProvider.getAddress());
+        expect(taxonomy.streamId.getId()).toBe(testStream.streamId.getId());
+      }
+    }
+  });
+
+  test('client high-level methods work correctly', async () => {
+    const clientResult = await client.listTaxonomiesByHeight({
+      limit: 10,
+      latestOnly: true
+    });
+
+    expect(Array.isArray(clientResult)).toBe(true);
+    
+    // Should match result from composed action
+    const composedResult = await composedAction.listTaxonomiesByHeight({
+      limit: 10,
+      latestOnly: true
+    });
+    
+    expect(clientResult.length).toBe(composedResult.length);
+  });
+
+  test('error handling works for invalid parameters', async () => {
+    // Test very large invalid height range (should return empty results, not throw)
+    const result = await composedAction.listTaxonomiesByHeight({
+      fromHeight: 999999,
+      toHeight: 1000000
+    });
+    
+    // Should return empty array for non-existent height range
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBe(0);
+  });
+
+  test('getTaxonomiesForStreams batch processing works', async () => {
+    // Get some existing streams to test with
+    const allTaxonomies = await composedAction.listTaxonomiesByHeight({
+      limit: 20,
+      latestOnly: true
+    });
+
+    if (allTaxonomies.length >= 2) {
+      // Get unique streams for batch test
+      const uniqueStreams = new Map();
+      for (const taxonomy of allTaxonomies) {
+        const key = `${taxonomy.dataProvider.getAddress()}_${taxonomy.streamId.getId()}`;
+        if (!uniqueStreams.has(key)) {
+          uniqueStreams.set(key, {
+            dataProvider: taxonomy.dataProvider,
+            streamId: taxonomy.streamId
+          });
+          if (uniqueStreams.size >= 3) break;
+        }
+      }
+
+      const testStreams = Array.from(uniqueStreams.values()).slice(0, 3);
+      
+      const batchResult = await composedAction.getTaxonomiesForStreams({
+        streams: testStreams,
+        latestOnly: true
+      });
+
+      expect(Array.isArray(batchResult)).toBe(true);
+      
+      // Verify all results belong to one of the requested streams
+      const requestedStreamKeys = testStreams.map(s => 
+        `${s.dataProvider.getAddress()}_${s.streamId.getId()}`
+      );
+      
+      for (const taxonomy of batchResult) {
+        const taxonomyKey = `${taxonomy.dataProvider.getAddress()}_${taxonomy.streamId.getId()}`;
+        expect(requestedStreamKeys).toContain(taxonomyKey);
+      }
+    }
+  });
+
+  test('both methods handle null/undefined parameters gracefully', async () => {
+    // Test with minimal parameters
+    const result1 = await composedAction.listTaxonomiesByHeight({});
+    expect(Array.isArray(result1)).toBe(true);
+
+    // Test client method with minimal parameters
+    const result2 = await client.listTaxonomiesByHeight();
+    expect(Array.isArray(result2)).toBe(true);
+  });
+});

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -5,7 +5,7 @@ import { GenericResponse } from "@trufnetwork/kwil-js/dist/core/resreq";
 import { TxReceipt } from "@trufnetwork/kwil-js/dist/core/tx";
 import { MANAGER_PRIVATE_KEY } from "./trufnetwork.setup";
 
-export const TEST_ENDPOINT = "http://localhost:8484";
+export const TEST_ENDPOINT = process.env.TEST_ENDPOINT || "http://localhost:8484";
 
 export const testWithDefaultWallet = createTestContexts({
   default: "0x0000000000000000000000000000000000000000100000000100000000000001",


### PR DESCRIPTION
This commit implements height-based taxonomy querying functionality to support efficient explorer synchronization by detecting taxonomy changes within specific block height ranges.

<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/truf-network/issues/1080

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new methods for querying taxonomy data by block height and for specific streams, enabling advanced filtering, pagination, and batch processing.
  * Expanded client API to support taxonomy queries directly.
  * Enhanced example scripts and documentation to demonstrate new taxonomy querying capabilities.

* **Documentation**
  * Updated API reference and example READMEs with detailed usage instructions and sample outputs for taxonomy querying.
  * Added integration test documentation with setup, usage, and troubleshooting guidance.

* **Tests**
  * Introduced comprehensive unit and integration tests for taxonomy querying methods, covering various scenarios and edge cases.

* **Chores**
  * Improved environment variable configuration for integration tests, allowing endpoint customization via environment variables.
  * Updated example dependencies for better local development support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->