### PR TITLE
fix: resolve failing CI due to Docker network conflicts

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,5 +8,6 @@ export default defineConfig({
     setupFiles: ['dotenv/config', 'disposablestack/auto'],
     maxConcurrency: 1, // Disable concurrency to avoid nonce errors
     fileParallelism: false,
+    hookTimeout: 60000, // 60 seconds for setup hooks
   },
 })


### PR DESCRIPTION
Addresses critical CI failures where integration tests were failing due to Docker network conflicts and container cleanup race conditions. The GitHub Actions environment would encounter "network already exists" errors and "network has active endpoints" errors, while local `gh act` tests passed successfully.

resolves: https://github.com/trufnetwork/truf-network/issues/1174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Improved reliability of integration test setup/teardown with safer existence checks and synchronized cleanup to reduce flakiness.
  - Added clearer logging during test environment initialization and shutdown for easier troubleshooting.
  - Increased setup hook timeout to 60 seconds to accommodate slower environments.
  - Aligned test admin account configuration with the manager account for consistency across migrations.
- Chores
  - General stability improvements to test workflows, leading to more predictable CI runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->