### PR TITLE
feat: view human-readable database size and v2 route for DBsize

### DIFF
--- a/src/contracts-api/action.ts
+++ b/src/contracts-api/action.ts
@@ -937,13 +937,23 @@ export class Action {
    * Returns the size of database
    */
   public async getDatabaseSize(): Promise<BigInt> {
-    const result = await this.call<{ database_size: BigInt }[]>("get_database_size", {})
+    const result = await this.call<{ database_size: BigInt }[]>("get_database_size_v2", {})
     return result
       .map((rows) => {
         const raw = rows[0].database_size;
         const asBigInt = BigInt(raw.toString());
         return asBigInt;
       }).throw();
+  }
+
+  /**
+   * Returns the size of database in human-readable format (e.g., "22 GB", "1.5 TB")
+   */
+  public async getDatabaseSizePretty(): Promise<string> {
+    const result = await this.call<{ database_size_pretty: string }[]>("get_database_size_v2_pretty", {})
+    return result
+      .map((rows) => rows[0].database_size_pretty)
+      .throw();
   }
 
   /**

--- a/tests/integration/databaseSize.test.ts
+++ b/tests/integration/databaseSize.test.ts
@@ -22,4 +22,17 @@ describe.sequential("Get Database Size", { timeout: 360000 }, () => {
       expect(databaseSize).toBeGreaterThan(0n)
     }
   )
+
+  testWithDefaultWallet(
+    "should get database size in human-readable format",
+    async ({ defaultClient }) => {
+      const actions = defaultClient.loadAction()
+      const databaseSizePretty = await actions.getDatabaseSizePretty()
+
+      expect(databaseSizePretty).toBeTruthy()
+      expect(typeof databaseSizePretty).toBe("string")
+      // Should contain a number followed by a unit (e.g., "22 GB", "1.5 MB")
+      expect(databaseSizePretty).toMatch(/\d+.*\s*(bytes|kB|MB|GB|TB)/i)
+    }
+  )
 });


### PR DESCRIPTION
Change the action route for `getDatabaseSize()` to v2 route and adds `getDatabaseSizePretty()` method to the Action class, enabling clients to retrieve database size in a user-friendly format (e.g., "22 GB", "1.5 TB") instead of raw byte counts.

This complements the existing `getDatabaseSize()` method by providing a more accessible view of database storage metrics for end users and dashboards.

resolves: https://github.com/trufnetwork/truf-network/issues/1219

related file: https://github.com/trufnetwork/node/blob/main/internal/migrations/024-get-database-size-v2.sql

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a human-readable database size output that returns values like “123 MB” for easier interpretation.
  - Existing numeric database size retrieval remains available; no breaking changes for current integrations.

- Tests
  - Added integration test to validate the human-readable database size format, ensuring it returns a string with correct numeric value and unit (bytes, kB, MB, GB, TB).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->